### PR TITLE
fix: step runner respects shebang

### DIFF
--- a/pkg/util/step.go
+++ b/pkg/util/step.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -22,18 +23,83 @@ func (s *Step) IsEmpty() bool {
 
 func (s *Step) Run(ctx context.Context) (string, error) {
 	var cmd *exec.Cmd
-
-	shell := GetShell()
+	var err error
 
 	if s.Inline != "" {
-		cmd = exec.CommandContext(ctx, shell)
-		cmd.Stdin = strings.NewReader(s.Inline)
+		cmd, err = s.createInlineCommand(ctx)
+		if err != nil {
+			return "", err
+		}
 	} else {
-		cmd = exec.CommandContext(ctx, shell, s.File)
+		cmd, err = s.createFileCommand(ctx)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+// createInlineCommand executes inline scripts with shebang support.
+// Scripts with shebangs are written to temp files in the current directory to preserve relative paths.
+func (s *Step) createInlineCommand(ctx context.Context) (*exec.Cmd, error) {
+	if strings.HasPrefix(strings.TrimSpace(s.Inline), "#!") {
+		tmpFile, err := os.CreateTemp(".", ".gevals-step-*.sh")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create temp script file: %w", err)
+		}
+		tmpPath := tmpFile.Name()
+
+		if _, err := tmpFile.WriteString(s.Inline); err != nil {
+			tmpFile.Close()
+			os.Remove(tmpPath)
+			return nil, fmt.Errorf("failed to write temp script: %w", err)
+		}
+		tmpFile.Close()
+
+		if err := ensureExecutable(tmpPath); err != nil {
+			os.Remove(tmpPath)
+			return nil, err
+		}
+
+		cmd := exec.CommandContext(ctx, tmpPath)
+		go func() {
+			<-ctx.Done()
+			os.Remove(tmpPath)
+		}()
+		return cmd, nil
+	}
+
+	shell := GetShell()
+	cmd := exec.CommandContext(ctx, shell)
+	cmd.Stdin = strings.NewReader(s.Inline)
+	return cmd, nil
+}
+
+// createFileCommand executes a script file directly to respect its shebang.
+func (s *Step) createFileCommand(ctx context.Context) (*exec.Cmd, error) {
+	if err := ensureExecutable(s.File); err != nil {
+		return nil, err
+	}
+	return exec.CommandContext(ctx, s.File), nil
+}
+
+func ensureExecutable(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	if info.Mode()&0100 != 0 {
+		return nil
+	}
+
+	if err := os.Chmod(path, info.Mode()|0111); err != nil {
+		return fmt.Errorf("failed to make script executable: %w", err)
+	}
+
+	return nil
 }
 
 func (s *Step) GetValue() (string, error) {


### PR DESCRIPTION
This fixes a bug where running a step that includes a shebang does not actually respect the shebang (e.g. `sh` may be used instead of `bash`)