### PR TITLE
feat: add llm judge for evaluating responses

### DIFF
--- a/pkg/eval/config.go
+++ b/pkg/eval/config.go
@@ -7,6 +7,7 @@ import (
 
 	"sigs.k8s.io/yaml"
 
+	"github.com/genmcp/gevals/pkg/llmjudge"
 	"github.com/genmcp/gevals/pkg/util"
 )
 
@@ -25,8 +26,9 @@ type EvalMetadata struct {
 
 type EvalConfig struct {
 	// Agent and MCP configuration
-	AgentFile     string `json:"agentFile"`
-	McpConfigFile string `json:"mcpConfigFile"`
+	AgentFile     string                       `json:"agentFile"`
+	McpConfigFile string                       `json:"mcpConfigFile"`
+	LLMJudge      *llmjudge.LLMJudgeEvalConfig `json:"llmJudge"`
 
 	// Advanced mode: different assertion sets
 	TaskSets []TaskSet `json:"taskSets,omitempty"`

--- a/pkg/llmjudge/config.go
+++ b/pkg/llmjudge/config.go
@@ -1,0 +1,66 @@
+package llmjudge
+
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	EvaluationModeExact    = "EXACT"
+	EvaluationModeContains = "CONTAINS"
+)
+
+type LLMJudgeEvalConfig struct {
+	Env *LLMJudgeEnvConfig `json:"env,omitempty"`
+}
+
+type LLMJudgeEnvConfig struct {
+	BaseUrlKey   string `json:"baseUrlKey"`
+	ApiKeyKey    string `json:"apiKeyKey"`
+	ModelNameKey string `json:"modelNameKey"`
+}
+
+type LLMJudgeTaskConfig struct {
+	Contains string `json:"contains,omitempty"`
+	Exact    string `json:"exact,omitempty"`
+}
+
+func (cfg *LLMJudgeEvalConfig) BaseUrl() string {
+	return os.Getenv(cfg.Env.BaseUrlKey)
+}
+
+func (cfg *LLMJudgeEvalConfig) ApiKey() string {
+	return os.Getenv(cfg.Env.ApiKeyKey)
+}
+
+func (cfg *LLMJudgeEvalConfig) ModelName() string {
+	return os.Getenv(cfg.Env.ModelNameKey)
+}
+
+func (cfg *LLMJudgeTaskConfig) EvaluationMode() string {
+	if cfg.Exact != "" {
+		return EvaluationModeExact
+	}
+
+	return EvaluationModeContains
+}
+
+func (cfg *LLMJudgeTaskConfig) ReferenceAnswer() string {
+	if cfg.Exact != "" {
+		return cfg.Exact
+	}
+
+	return cfg.Contains
+}
+
+func (cfg *LLMJudgeTaskConfig) Validate() error {
+	if cfg.Exact == "" && cfg.Contains == "" {
+		return fmt.Errorf("one of contains or exact must be specified")
+	}
+
+	if cfg.Exact != "" && cfg.Contains != "" {
+		return fmt.Errorf("only one of contains or exact can be specified, not both")
+	}
+
+	return nil
+}

--- a/pkg/llmjudge/llmjudge.go
+++ b/pkg/llmjudge/llmjudge.go
@@ -1,0 +1,172 @@
+package llmjudge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/openai/openai-go/v2"
+	"github.com/openai/openai-go/v2/option"
+)
+
+const (
+	openaiSeed = 0 // allows for consistent eval results
+)
+
+var (
+	submitJudgementFunction = openai.FunctionDefinitionParam{
+		Name:        "submit_judgement",
+		Description: openai.String(""),
+		Parameters: openai.FunctionParameters{
+			"type": "object",
+			"properties": map[string]any{
+				"passed": map[string]any{
+					"type":        "boolean",
+					"description": "Binary result: true for pass, false for fail",
+				},
+				"reason": map[string]any{
+					"type":        "string",
+					"description": "A detailed explanation for the score, referencing the evaluation criterion and the text",
+				},
+				"failureCategory": map[string]any{
+					"type":        "string",
+					"description": "If passed is false, specify the reason. Use 'n/a' if passing",
+					"enum": []string{
+						"semantic_mismatch",
+						"missing_information",
+						"contains_extra_info",
+						"n/a",
+					},
+				},
+			},
+			"required": []string{"passed", "reason", "failureCategory"},
+		},
+	}
+)
+
+type LLMJudge interface {
+	EvaluateText(ctx context.Context, judgeConfig *LLMJudgeTaskConfig, prompt, output string) (*LLMJudgeResult, error)
+}
+
+type LLMJudgeResult struct {
+	Passed          bool   `json:"passed"`
+	Reason          string `json:"reason"`
+	FailureCategory string `json:"failureCategory"`
+}
+
+type llmJudge struct {
+	client openai.Client
+	model  string
+}
+
+type noopLLMJudge struct{}
+
+func (n *noopLLMJudge) EvaluateText(ctx context.Context, judgeConfig *LLMJudgeTaskConfig, prompt, output string) (*LLMJudgeResult, error) {
+	return &LLMJudgeResult{
+		Passed:          true,
+		Reason:          "noop judge always passes",
+		FailureCategory: "n/a",
+	}, nil
+}
+
+func NewLLMJudge(cfg *LLMJudgeEvalConfig) (LLMJudge, error) {
+	if cfg == nil {
+		return &noopLLMJudge{}, nil
+	}
+	if cfg.Env == nil {
+		return nil, fmt.Errorf("llm judge env config is required to create an llm judge")
+	}
+	baseUrl := cfg.BaseUrl()
+	apiKey := cfg.ApiKey()
+	model := cfg.ModelName()
+
+	var missingVars []string
+	if baseUrl == "" {
+		missingVars = append(missingVars, fmt.Sprintf("%s (base URL)", cfg.Env.BaseUrlKey))
+	}
+	if apiKey == "" {
+		missingVars = append(missingVars, fmt.Sprintf("%s (API key)", cfg.Env.ApiKeyKey))
+	}
+	if model == "" {
+		missingVars = append(missingVars, fmt.Sprintf("%s (model name)", cfg.Env.ModelNameKey))
+	}
+
+	if len(missingVars) > 0 {
+		return nil, fmt.Errorf("missing required environment variables for LLM judge: %v", missingVars)
+	}
+
+	client := openai.NewClient(
+		option.WithBaseURL(baseUrl),
+		option.WithAPIKey(apiKey),
+	)
+
+	return &llmJudge{
+		client: client,
+		model:  model,
+	}, nil
+}
+
+func (j *llmJudge) EvaluateText(ctx context.Context, judgeConfig *LLMJudgeTaskConfig, prompt, output string) (*LLMJudgeResult, error) {
+	systemPrompt, err := BuildSystemPrompt(SystemPromptData{
+		EvaluationMode:  judgeConfig.EvaluationMode(),
+		ReferenceAnswer: judgeConfig.ReferenceAnswer(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	userPrompt, err := BuildUserPrompt(UserPromptData{
+		UserPrompt:    prompt,
+		ModelResponse: output,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	params := openai.ChatCompletionNewParams{
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage(systemPrompt),
+			openai.UserMessage(userPrompt),
+		},
+		Tools: []openai.ChatCompletionToolUnionParam{
+			{
+				OfFunction: &openai.ChatCompletionFunctionToolParam{
+					Function: submitJudgementFunction,
+				},
+			},
+		},
+		ToolChoice: openai.ToolChoiceOptionFunctionToolChoice(openai.ChatCompletionNamedToolChoiceFunctionParam{Name: submitJudgementFunction.Name}),
+		Seed:       openai.Int(openaiSeed),
+		Model:      j.model,
+	}
+
+	completion, err := j.client.Chat.Completions.New(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call llm judge: %w", err)
+	}
+
+	if len(completion.Choices) == 0 {
+		return nil, fmt.Errorf("no completion choices returned from LLM")
+	}
+
+	toolCalls := completion.Choices[0].Message.ToolCalls
+
+	if len(toolCalls) != 1 {
+		return nil, fmt.Errorf("failed to call the correct number of tools, expected 1 call, got %d", len(toolCalls))
+	}
+
+	toolCall := toolCalls[0]
+
+	if toolCall.Function.Name != submitJudgementFunction.Name {
+		return nil, fmt.Errorf("llm judge failed to call '%s' tool, called '%s' instead", submitJudgementFunction.Name, toolCall.Function.Name)
+	}
+
+	result := &LLMJudgeResult{}
+
+	err = json.Unmarshal([]byte(toolCall.Function.Arguments), result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshall '%s' tool call arguments: %w", submitJudgementFunction.Name, err)
+	}
+
+	return result, nil
+}

--- a/pkg/llmjudge/prompts.go
+++ b/pkg/llmjudge/prompts.go
@@ -1,0 +1,90 @@
+package llmjudge
+
+import (
+	"bytes"
+	"text/template"
+)
+
+var (
+	systemPromptTemplate = template.Must(template.New("systemPrompt").Parse(
+		`You are a specialized LLM evaluator. Your **one and only job** is to perform a semantic comparison between a [MODEL_RESPONSE] and a [REFERENCE_ANSWER] based on the **{{.EvaluationMode}}** criterion.
+
+### Your Single Criterion: {{.EvaluationMode}}
+
+{{if eq .EvaluationMode "CONTAINS"}}
+* **CONTAINS Definition**:
+* **Goal**: The [MODEL_RESPONSE] must semantically include *all* the core information in the [REFERENCE_ANSWER].
+* **Pass (Score 1.0)**: The response contains the reference answer's meaning. The information can be presented in ANY format (prose, bullet points, paragraphs, etc.). Extra, correct, and non-contradictory information is acceptable.
+* **Fail (Score 0.0)**: The response is missing the core information from the reference answer.
+* **Important**: Focus on SEMANTIC CONTENT, not format or phrasing. If the MODEL_RESPONSE conveys the same facts/information as REFERENCE_ANSWER (even in different words or structure), it should PASS.
+* **Failure Categories**:
+  - Use "missing_information" if the MODEL_RESPONSE lacks core information from REFERENCE_ANSWER
+  - Use "semantic_mismatch" if the MODEL_RESPONSE contradicts or has different meaning
+  - Use "n/a" if passing
+{{else if eq .EvaluationMode "EXACT"}}
+* **EXACT Definition**:
+* **Goal**: The [MODEL_RESPONSE] must be *semantically equivalent* to the [REFERENCE_ANSWER].
+* **Pass (Score 1.0)**: The response means the exact same thing as the reference. Simple rephrasing is fine (e.g., "Paris is the capital" vs. "The capital is Paris").
+* **Fail (Score 0.0)**: The response omits *any* information, adds *any* new information (even if correct), or has a different meaning.
+* **Failure Categories**:
+  - Use "missing_information" if the MODEL_RESPONSE omits information from REFERENCE_ANSWER
+  - Use "contains_extra_info" if the MODEL_RESPONSE adds information not in REFERENCE_ANSWER
+  - Use "semantic_mismatch" if the MODEL_RESPONSE has a different meaning or contradicts
+  - Use "n/a" if passing
+{{end}}
+
+<ground_truth_reference>
+{{.ReferenceAnswer}}
+</ground_truth_reference>
+
+You MUST always respond by calling the ` + "`submit_judgement`" + ` tool with:
+- passed: boolean (true/false)
+- reason: detailed explanation referencing the specific criterion
+- failureCategory: one of the categories listed above
+
+Do not add any conversational text.
+`))
+
+	userPromptTemplate = template.Must(template.New("userPrompt").Parse(
+		`<user_prompt_context>
+{{.UserPrompt}}
+</user_prompt_context>
+
+<model_output_to_evaluate>
+{{.ModelResponse}}
+</model_output_to_evaluate>
+
+Evaluate whether the content in <model_output_to_evaluate> contains all the core information from <ground_truth_reference>. Remember to focus on semantic meaning, not exact wording or format.
+`))
+)
+
+type SystemPromptData struct {
+	// EvaluationMode should be "CONTAINS" or "EXACT"
+	EvaluationMode  string
+	ReferenceAnswer string
+}
+
+type UserPromptData struct {
+	UserPrompt    string
+	ModelResponse string
+}
+
+func BuildSystemPrompt(data SystemPromptData) (string, error) {
+	var out bytes.Buffer
+	err := systemPromptTemplate.Execute(&out, data)
+	if err != nil {
+		return "", err
+	}
+
+	return out.String(), nil
+}
+
+func BuildUserPrompt(data UserPromptData) (string, error) {
+	var out bytes.Buffer
+	err := userPromptTemplate.Execute(&out, data)
+	if err != nil {
+		return "", err
+	}
+
+	return out.String(), nil
+}

--- a/pkg/task/config_test.go
+++ b/pkg/task/config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/genmcp/gevals/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,25 +26,27 @@ func TestFromFile(t *testing.T) {
 					Difficulty: DifficultyEasy,
 				},
 				Steps: TaskSteps{
-					SetupScript: Step{
+					SetupScript: &util.Step{
 						Inline: `#!/usr/bin/env bash
 kubectl delete namespace create-pod-test --ignore-not-found
 kubectl create namespace create-pod-test`,
 					},
-					VerifyScript: Step{
-						Inline: `#!/usr/bin/env bash
+					VerifyScript: &VerifyStep{
+						Step: &util.Step{
+							Inline: `#!/usr/bin/env bash
 if kubectl wait --for=condition=Ready pod/web-server -n create-pod-test --timeout=120s; then
     exit 0
 else
     exit 1
 fi`,
+						},
 					},
-					CleanupScript: Step{
+					CleanupScript: &util.Step{
 						Inline: `#!/usr/bin/env bash
 kubectl delete pod web-server -n create-pod-test --ignore-not-found
 kubectl delete namespace create-pod-test --ignore-not-found`,
 					},
-					Prompt: Step{
+					Prompt: &util.Step{
 						Inline: "Please create a nginx pod named web-server in the create-pod-test namespace",
 					},
 				},

--- a/pkg/task/run.go
+++ b/pkg/task/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/genmcp/gevals/pkg/agent"
+	"github.com/genmcp/gevals/pkg/llmjudge"
 )
 
 type TaskRunner interface {
@@ -15,19 +16,32 @@ type TaskRunner interface {
 }
 
 type taskRunner struct {
-	steps TaskSteps
+	steps    TaskSteps
+	judge    llmjudge.LLMJudge
+	judgeCfg *llmjudge.LLMJudgeTaskConfig
+	prompt   string
+	output   string
 }
 
-func NewTaskRunner(cfg *TaskSpec) (TaskRunner, error) {
+func NewTaskRunner(cfg *TaskSpec, judge llmjudge.LLMJudge) (TaskRunner, error) {
 	if cfg.Steps.Prompt.IsEmpty() {
 		return nil, fmt.Errorf("prompt.inline or prompt.file must be set on a task to run it")
 	}
-	if cfg.Steps.VerifyScript.IsEmpty() {
-		return nil, fmt.Errorf("verify.inline or verify.file must be set on a task to run it")
+
+	// Validate the verify step
+	if err := cfg.Steps.VerifyScript.Validate(); err != nil {
+		return nil, err
+	}
+
+	// If judge is nil and there is a llm judge task config, report an error
+	if cfg.Steps.VerifyScript.LLMJudgeTaskConfig != nil && judge == nil {
+		return nil, fmt.Errorf("verify.exact and verify.contains require that the eval contains an llm judge config")
 	}
 
 	return &taskRunner{
-		steps: cfg.Steps,
+		steps:    cfg.Steps,
+		judge:    judge,
+		judgeCfg: cfg.Steps.VerifyScript.LLMJudgeTaskConfig,
 	}, nil
 }
 
@@ -53,15 +67,39 @@ func (r *taskRunner) RunAgent(ctx context.Context, agent agent.Runner) (string, 
 		return "", fmt.Errorf("failed to get prompt: %w", err)
 	}
 
+	r.prompt = prompt
+
 	result, err := agent.RunTask(ctx, prompt)
 	if err != nil {
 		return "", fmt.Errorf("failed to run agent: %w", err)
 	}
 
-	return result.GetOutput(), nil
+	output := result.GetOutput()
+
+	r.output = output
+
+	return output, nil
 }
 
 func (r *taskRunner) Verify(ctx context.Context) (string, error) {
 	// no need to verify that Verify is set - this is validated in NewTaskRunner
-	return r.steps.VerifyScript.Run(ctx)
+	if r.steps.VerifyScript.Step != nil && !r.steps.VerifyScript.Step.IsEmpty() {
+		return r.steps.VerifyScript.Step.Run(ctx)
+	}
+
+	// Using LLM judge - validate that state exists
+	if r.prompt == "" || r.output == "" {
+		return "", fmt.Errorf("cannot run LLM judge verification: RunAgent() must be called before Verify()")
+	}
+
+	out, err := r.judge.EvaluateText(ctx, r.judgeCfg, r.prompt, r.output)
+	if err != nil {
+		return "", err
+	}
+
+	if !out.Passed {
+		return "", fmt.Errorf("evaluation failed for reason '%s' because '%s'", out.FailureCategory, out.Reason)
+	}
+
+	return "", nil
 }


### PR DESCRIPTION
This PR allows for the creation of verification around LLM responses and their contents within tasks, not just verifying some external output.

Using the genmcp feature requests demo, I was able to create the following eval/tasks and have assertions/verification pass:

```yaml
kind: Eval
metadata:
  name: startup-issue-tracker-evals
config:
  agentFile: claude-code.yaml
  mcpConfigFile: mcp-config.yaml
  llmJudge:
    env:
      baseUrlKey: MODEL_BASE_URL
      apiKeyKey: MODEL_API_KEY
      modelNameKey: MODEL_NAME
  taskSets:
    - path: ./tasks/most-requested-feature/most-requested-feature.yaml
      assertions:
        toolsUsed:
          - server: features
            tool: get_features-top
          - server: features
            tool: get_features-id
```

```yaml
kind: Task
metadata:
  name: most-requested-feature
  difficulty: easy
steps:
  prompt:
    inline: What is the most requested feature for my app?
  verify:
    contains: The most requested feature is dark mode, with support for features like automatic detection of system preference and a manual toggle in user settings.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tasks can now be verified using LLM-based semantic evaluation with EXACT or CONTAINS matching modes
  * Added LLM judge configuration support to evaluation and task settings
  * Added server readiness signaling for improved startup observability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->