### PR TITLE
feat: add gemini-cli agent support with MCP integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ go.work.sum
 # built binary
 /agent
 /gevals
+
+# gemini-cli
+.gemini

--- a/examples/kube-mcp-server/gemini/eval.yaml
+++ b/examples/kube-mcp-server/gemini/eval.yaml
@@ -1,0 +1,20 @@
+kind: Eval
+metadata:
+  name: "kubernetes-basic-operations"
+config:
+  agent:
+    type: "builtin.gemini-cli"
+  mcpConfigFile: ../mcp-config.yaml
+  llmJudge:
+    env:
+      baseUrlKey: JUDGE_BASE_URL
+      apiKeyKey: JUDGE_API_KEY
+      modelNameKey: JUDGE_MODEL_NAME
+  taskSets:
+    - glob: ../tasks/*/*.yaml
+      assertions:
+        toolsUsed:
+          - server: kubernetes
+            toolPattern: ".*"
+        minToolCalls: 1
+        maxToolCalls: 20

--- a/pkg/agent/builtin.go
+++ b/pkg/agent/builtin.go
@@ -3,6 +3,7 @@ package agent
 var builtinTypes = map[string]BuiltinAgent{
 	"openai-agent": &OpenAIAgent{},
 	"claude-code":  &ClaudeCodeAgent{},
+	"gemini-cli":   &GeminiCLIAgent{},
 }
 
 // GetBuiltinType retrieves a builtin agent by name

--- a/pkg/agent/gemini_cli.go
+++ b/pkg/agent/gemini_cli.go
@@ -1,0 +1,44 @@
+package agent
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+type GeminiCLIAgent struct{}
+
+func (a *GeminiCLIAgent) Name() string {
+	return "gemini-cli"
+}
+
+func (a *GeminiCLIAgent) Description() string {
+	return "Google's Gemini CLI"
+}
+
+func (a *GeminiCLIAgent) RequiresModel() bool {
+	return false // Gemini CLI manages its own model selection
+}
+
+func (a *GeminiCLIAgent) ValidateEnvironment() error {
+	if _, err := exec.LookPath("gemini"); err != nil {
+		return fmt.Errorf("'gemini' binary not found in PATH")
+	}
+	return nil
+}
+
+func (a *GeminiCLIAgent) GetDefaults(model string) (*AgentSpec, error) {
+	separator := ","
+	useVirtualHome := false
+	return &AgentSpec{
+		Metadata: AgentMetadata{
+			Name: "gemini-cli",
+		},
+		Commands: AgentCommands{
+			UseVirtualHome:            &useVirtualHome,
+			ArgTemplateMcpServer:      "{{ .URL }}",
+			ArgTemplateAllowedTools:   "{{ .ToolName }}",
+			AllowedToolsJoinSeparator: &separator,
+			RunPrompt:                 `sh -c 'SERVER_NAME="mcp-eval-$$" && gemini mcp add "$SERVER_NAME" {{ .McpServerFileArgs }} --scope project --transport http --trust >/dev/null 2>&1 && trap "gemini mcp remove \"$SERVER_NAME\" >/dev/null 2>&1 || true" EXIT && gemini --allowed-mcp-server-names "$SERVER_NAME" --allowed-tools "{{ .AllowedToolArgs }}" --approval-mode yolo --output-format text --prompt "{{ .Prompt }}"'`,
+		},
+	}, nil
+}


### PR DESCRIPTION
Adds support for using gemini-cli as an agent for evaluations with proper MCP tool call recording. The integration uses a wrapper script to dynamically configure gemini with the MCP proxy server, ensuring tool calls are properly intercepted and recorded for assertion validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gemini CLI agent for running AI-powered evaluations
  * Introduced evaluation configuration for Kubernetes basic operations testing
  * Expanded agent ecosystem with support for Gemini CLI integration in evaluation workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->