### PR TITLE
README: document LLM judge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ gevals validates MCP servers by:
 1. 🔧 Running setup scripts (e.g., create test namespace)
 2. 🤖 Giving an AI agent a task prompt (e.g., "create a nginx pod")
 3. 📝 Recording which MCP tools the agent uses
-4. ✅ Verifying the task succeeded (e.g., pod is running)
+4. ✅ Verifying the task succeeded via scripts OR LLM judge (e.g., pod is running, or response contains expected content)
 5. 🔍 Checking assertions (e.g., did agent call `pods_create`?)
 6. 🧹 Running cleanup scripts
 
@@ -39,6 +39,11 @@ metadata:
 config:
   agentFile: agent.yaml           # How to run your AI agent
   mcpConfigFile: mcp-config.yaml  # Your MCP server config
+  llmJudge:                        # Optional: LLM judge for semantic verification
+    env:
+      baseUrlKey: JUDGE_BASE_URL   # Env var name for LLM API base URL
+      apiKeyKey: JUDGE_API_KEY     # Env var name for LLM API key
+      modelNameKey: JUDGE_MODEL_NAME # Env var name for model name
   taskSets:
     - path: tasks/create-pod.yaml
       assertions:
@@ -80,12 +85,17 @@ steps:
   setup:
     file: setup.sh      # Creates test namespace
   verify:
-    file: verify.sh     # Checks pod is running
+    file: verify.sh     # Script-based: Checks pod is running
+    # OR use LLM judge (requires llmJudge config in eval.yaml):
+    # contains: "pod is running"  # Semantic check: response contains this text
+    # exact: "The pod web-server is running"  # Semantic check: exact match
   cleanup:
     file: cleanup.sh    # Deletes pod
   prompt:
     inline: Create a nginx pod named web-server in the test-namespace
 ```
+
+Note: You must choose either script-based verification (`file` or `inline`) OR LLM judge verification (`contains` or `exact`), not both.
 
 ## Assertions
 
@@ -170,6 +180,73 @@ steps:
       #!/usr/bin/env bash
       kubectl create namespace test-ns
 ```
+
+## LLM Judge Verification
+
+Instead of script-based verification, you can use an LLM judge to semantically evaluate agent responses. This is useful when:
+- You want to check if the agent's response contains specific information (semantic matching)
+- The expected output format may vary but the meaning should be consistent
+- You're testing tasks where the agent provides text responses rather than performing actions
+
+### Configuration
+
+First, configure the LLM judge in your `eval.yaml`:
+
+```yaml
+config:
+  llmJudge:
+    env:
+      baseUrlKey: JUDGE_BASE_URL    # Environment variable for LLM API base URL
+      apiKeyKey: JUDGE_API_KEY      # Environment variable for LLM API key
+      modelNameKey: JUDGE_MODEL_NAME # Environment variable for model name
+```
+
+Set the required environment variables before running:
+```bash
+export JUDGE_BASE_URL="https://api.openai.com/v1"
+export JUDGE_API_KEY="sk-..."
+export JUDGE_MODEL_NAME="gpt-4o"
+```
+
+**Note**: The LLM judge currently only supports OpenAI-compatible APIs (APIs that follow the OpenAI API format). The implementation uses the OpenAI Go SDK with a configurable base URL, so you can use any OpenAI-compatible endpoint, but APIs with different formats are not supported.
+
+### Evaluation Modes
+
+The LLM judge supports two evaluation modes:
+
+**CONTAINS mode** (`verify.contains`):
+- Checks if the agent's response semantically contains all core information from the reference answer
+- Extra, correct, and non-contradictory information is acceptable
+- Format and phrasing differences are ignored (semantic matching)
+- Use when you want to verify the response includes specific information
+
+**EXACT mode** (`verify.exact`):
+- Checks if the agent's response is semantically equivalent to the reference answer
+- Simple rephrasing is acceptable (e.g., "Paris is the capital" vs "The capital is Paris")
+- Adding or omitting information will fail
+- Use when you need precise semantic equivalence
+
+**Note**: Both modes use the same LLM-based semantic evaluation approach. The difference is only in the system prompt instructions given to the judge LLM. See [`pkg/llmjudge/prompts.go`](pkg/llmjudge/prompts.go) for the implementation details.
+
+### Usage in Tasks
+
+In your task YAML, use `verify.contains` or `verify.exact` instead of `verify.file` or `verify.inline`:
+
+```yaml
+steps:
+  verify:
+    contains: "mysql:8.0.36"  # Response must contain this information
+```
+
+```yaml
+steps:
+  verify:
+    exact: "The pod web-server is running in namespace test-ns"  # Response must match exactly (semantically)
+```
+
+**Important**: You cannot use both script-based verification and LLM judge verification in the same task. Choose one method:
+- Script-based: `verify.file` or `verify.inline` (runs a script that returns exit code 0 for success)
+- LLM judge: `verify.contains` or `verify.exact` (semantically evaluates the agent's text response)
 
 ## Results
 


### PR DESCRIPTION
Please check if I understood the LLM judge and the "verify" directive correctly and if I saw this right, that just the docs are missing…
Followup of PR #25
~~btw. is this really on purpose that the **baseUrl**  is called **baseUrlKey** in the config file? or maybe subject to change in a next PR 🤔 (skip the "key" for all three properties)~~ (edit - sorry, does make sense how it is now)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded verification options to support both script-based and LLM judge-based semantic verification.
  * Added comprehensive LLM Judge configuration guide with environment setup requirements.
  * Updated example tasks to demonstrate new verification method options.
  * Clarified that only one verification method may be used per task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->