### PR TITLE
docs: update claude skill and related docs

### DIFF
--- a/.claude/skills/create-eval/SKILL.md
+++ b/.claude/skills/create-eval/SKILL.md
@@ -17,7 +17,7 @@ When creating a full eval from scratch, you will need to:
 1. Create one or more tasks, see [tasks.md](tasks.md)
 2. Create a mcp config file, see [mcpConfig.md](mcpConfig.md)
 3. Create an agent file, see [agent.md](agent.md)
-4. Create a top-level eval file that references the rest of the files, see [eval.yaml](eval.yaml)
+4. Create a top-level eval file that references the rest of the files, see [eval.md](eval.md)
 
 However, in most cases you will not be creating an entirely new set of evals from scratch - you will just be modifying or
 extending an existing eval. In this case, you will only need to modify some of these files.
@@ -27,7 +27,7 @@ extending an existing eval. In this case, you will only need to modify some of t
 To run the evals, use:
 
 ```bash
-gevals run <path to eval yaml file>
+gevals eval <path to eval yaml file>
 ```
 
 The `gevals` binary may or may not be in the `$PATH`. If it is not in the path, ask the user where it is.

--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ kind: Agent
 metadata:
   name: "claude-code"
 commands:
+  useVirtualHome: false
   argTemplateMcpServer: "--mcp-config {{ .File }}"
   argTemplateAllowedTools: "mcp__{{ .ServerName }}__{{ .ToolName }}"
+  allowedToolsJoinSeparator: ","
   runPrompt: |-
-    claude {{ .McpServerFileArgs }} --print "{{ .Prompt }}"
+    claude {{ .McpServerFileArgs }} --strict-mcp-config --allowedTools "{{ .AllowedToolArgs }}" --print "{{ .Prompt }}"
 ```
 
 **tasks/create-pod.yaml** - Test task:

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -45,7 +45,7 @@ type AgentCommands struct {
 	// A template command to run the agent with a prompt and some mcp servers
 	// the prompt will be in {{ .Prompt }}
 	// the servers will be in {{ .McpServerFileArgs }}
-	// the allowed tools will be in {{ .AllowedTools }}
+	// the allowed tools will be in {{ .AllowedToolArgs }}
 	RunPrompt string `json:"runPrompt"`
 
 	// An optional command to get the version of the agent


### PR DESCRIPTION
Update claude skill and related docs

I tried to align README, code and claude skill
Please check thoroughly if I understood the config correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP agent configuration documentation with new fields and command-line flags.
  * Updated evaluation command guidance and file format references.

* **Configuration**
  * Added useVirtualHome and allowedToolsJoinSeparator configuration options for agents.
  * Added --strict-mcp-config and --allowedTools command-line flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->