### PR TITLE
Show agent and LLM details in verbose mode

### DIFF
--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -15,6 +15,7 @@ import (
 type Runner interface {
 	RunTask(ctx context.Context, prompt string) (AgentResult, error)
 	WithMcpServerInfo(mcpInfo McpServerInfo) Runner
+	AgentName() string
 }
 
 type McpServerInfo interface {
@@ -175,4 +176,8 @@ func (a *agentSpecRunner) WithMcpServerInfo(mcpInfo McpServerInfo) Runner {
 		AgentSpec: a.AgentSpec,
 		mcpInfo:   mcpInfo,
 	}
+}
+
+func (a *agentSpecRunner) AgentName() string {
+	return a.Metadata.Name
 }

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/genmcp/gevals/pkg/eval"
+	"github.com/genmcp/gevals/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -44,6 +45,7 @@ func NewEvalCmd() *cobra.Command {
 
 			// Run with progress
 			ctx := context.Background()
+			ctx = util.WithVerbose(ctx, verbose)
 			results, err := runner.RunWithProgress(ctx, run, display.handleProgress)
 			if err != nil {
 				return fmt.Errorf("eval failed: %w", err)

--- a/pkg/eval/runner.go
+++ b/pkg/eval/runner.go
@@ -11,6 +11,7 @@ import (
 	"github.com/genmcp/gevals/pkg/llmjudge"
 	"github.com/genmcp/gevals/pkg/mcpproxy"
 	"github.com/genmcp/gevals/pkg/task"
+	"github.com/genmcp/gevals/pkg/util"
 )
 
 type EvalResult struct {
@@ -270,6 +271,9 @@ func (r *evalRunner) executeTaskSteps(
 
 	agentRunner = agentRunner.WithMcpServerInfo(manager)
 
+	if util.IsVerbose(ctx) {
+		fmt.Printf("  → Agent '%s' is working…\n", agentRunner.AgentName())
+	}
 	out, err := taskRunner.RunAgent(ctx, agentRunner)
 	if err != nil {
 		result.TaskPassed = false

--- a/pkg/llmjudge/llmjudge.go
+++ b/pkg/llmjudge/llmjudge.go
@@ -46,6 +46,7 @@ var (
 
 type LLMJudge interface {
 	EvaluateText(ctx context.Context, judgeConfig *LLMJudgeTaskConfig, prompt, output string) (*LLMJudgeResult, error)
+	ModelName() string
 }
 
 type LLMJudgeResult struct {
@@ -67,6 +68,10 @@ func (n *noopLLMJudge) EvaluateText(ctx context.Context, judgeConfig *LLMJudgeTa
 		Reason:          "noop judge always passes",
 		FailureCategory: "n/a",
 	}, nil
+}
+
+func (n *noopLLMJudge) ModelName() string {
+	return "noop"
 }
 
 func NewLLMJudge(cfg *LLMJudgeEvalConfig) (LLMJudge, error) {
@@ -169,4 +174,8 @@ func (j *llmJudge) EvaluateText(ctx context.Context, judgeConfig *LLMJudgeTaskCo
 	}
 
 	return result, nil
+}
+
+func (j *llmJudge) ModelName() string {
+	return j.model
 }

--- a/pkg/task/run.go
+++ b/pkg/task/run.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/genmcp/gevals/pkg/agent"
 	"github.com/genmcp/gevals/pkg/llmjudge"
+	"github.com/genmcp/gevals/pkg/util"
 )
 
 type TaskRunner interface {
@@ -92,6 +93,10 @@ func (r *taskRunner) Verify(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("cannot run LLM judge verification: RunAgent() must be called before Verify()")
 	}
 
+	if util.IsVerbose(ctx) {
+		fmt.Printf("  → LLM judge '%s' is evaluating…\n", r.judge.ModelName())
+	}
+
 	out, err := r.judge.EvaluateText(ctx, r.judgeCfg, r.prompt, r.output)
 	if err != nil {
 		return "", err
@@ -99,6 +104,10 @@ func (r *taskRunner) Verify(ctx context.Context) (string, error) {
 
 	if !out.Passed {
 		return "", fmt.Errorf("evaluation failed for reason '%s' because '%s'", out.FailureCategory, out.Reason)
+	}
+
+	if util.IsVerbose(ctx) {
+		fmt.Printf("  → LLM judge reason: %+v\n", out.Reason)
 	}
 
 	return "", nil

--- a/pkg/util/context.go
+++ b/pkg/util/context.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"context"
+)
+
+type contextKey string
+
+const verboseKey contextKey = "verbose"
+
+// WithVerbose adds the verbose flag to the context
+func WithVerbose(ctx context.Context, verbose bool) context.Context {
+	return context.WithValue(ctx, verboseKey, verbose)
+}
+
+// IsVerbose returns true if verbose mode is enabled in the context
+func IsVerbose(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	v, ok := ctx.Value(verboseKey).(bool)
+	return ok && v
+}
+


### PR DESCRIPTION
Show more agent and LLM details in verbose mode
I wanted to double check if my config is good and the correct models are being picked up.

Also when the execution is blocked for a while (judge is working) it's nice to see what's happening now…

Feel free to decline this PR, if you think this is too much output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Verbose mode now displays agent progress messages and shows the agent name while tasks run.
  * Evaluation steps include the LLM/judge name and reason in verbose output for clearer diagnostics.
  * Verbose flag can be enabled per run and is propagated through progress reporting for consistent logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->