### PR TITLE
fix: mcpServers config: respect `env` configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,6 @@ build-gevals: clean
 .PHONY: build
 build: build-agent build-gevals
 
+.PHONY: test
+test:
+	go test ./...

--- a/README.md
+++ b/README.md
@@ -57,11 +57,27 @@ config:
 **mcp-config.yaml** - MCP server to test:
 ```yaml
 mcpServers:
+  # HTTP server example
   kubernetes:
     type: http
     url: http://localhost:8080/mcp
     enableAllTools: true
+
+  # Stdio server example with environment variables
+  filesystem:
+    type: stdio
+    command: npx
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-filesystem"
+      - "/workspace"
+    env:
+      DEBUG: "true"
+      LOG_LEVEL: "${LOG_LEVEL:-info}"  # Supports ${VAR} and ${VAR:-default} expansion
+    enableAllTools: true
 ```
+
+Note: The `env` field is only applicable to stdio servers. Environment variable values support expansion using `${VAR}` (required, error if not set) or `${VAR:-default}` (optional with default value).
 
 **agent.yaml** - AI agent configuration:
 ```yaml

--- a/pkg/mcpproxy/env_expand.go
+++ b/pkg/mcpproxy/env_expand.go
@@ -1,0 +1,134 @@
+package mcpproxy
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+)
+
+var (
+	// Pattern for ${VAR:-default} syntax (must come before ${VAR} pattern)
+	envWithDefaultPattern = regexp.MustCompile(`\$\{([^:}]+):-([^}]*)\}`)
+	// Pattern for ${VAR} syntax (required) - matches only if not already matched by default pattern
+	envRequiredPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
+)
+
+// ExpandEnv expands environment variable references in a string value.
+// Supports:
+//   - ${VAR} - required variable (error if not set)
+//   - ${VAR:-default} - optional with default value
+//
+// Returns the expanded string or an error if a required variable is missing.
+// Nested expansions are supported and processed recursively.
+func ExpandEnv(value string) (string, error) {
+	result := value
+	maxIterations := 10 // Prevent infinite loops
+	iteration := 0
+
+	for iteration < maxIterations {
+		iteration++
+		prevResult := result
+
+		// First, expand ${VAR:-default} patterns (these take precedence)
+		result = envWithDefaultPattern.ReplaceAllStringFunc(result, func(match string) string {
+			submatches := envWithDefaultPattern.FindStringSubmatch(match)
+			if len(submatches) != 3 {
+				return match
+			}
+			varName := submatches[1]
+			defaultValue := submatches[2]
+
+			if val, ok := os.LookupEnv(varName); ok && val != "" {
+				return val
+			}
+			// Expand the default value recursively
+			expandedDefault, err := expandOnce(defaultValue)
+			if err == nil && expandedDefault != defaultValue {
+				return expandedDefault
+			}
+			return defaultValue
+		})
+
+		// Then, expand ${VAR} patterns (required) - but skip any that contain :- (already processed)
+		missingVars := []string{}
+		result = envRequiredPattern.ReplaceAllStringFunc(result, func(match string) string {
+			// Skip if this contains :- (already handled by default pattern)
+			if regexp.MustCompile(`:-`).MatchString(match) {
+				return match
+			}
+
+			submatches := envRequiredPattern.FindStringSubmatch(match)
+			if len(submatches) != 2 {
+				return match
+			}
+			varName := submatches[1]
+
+			val, ok := os.LookupEnv(varName)
+			if !ok || val == "" {
+				missingVars = append(missingVars, match)
+				return match
+			}
+			return val
+		})
+
+		// Check if any required variables are missing
+		if len(missingVars) > 0 {
+			return "", fmt.Errorf("required environment variable(s) not set: %v", missingVars)
+		}
+
+		// If nothing changed, we're done
+		if result == prevResult {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+// expandOnce performs a single pass of expansion (used for nested defaults)
+func expandOnce(value string) (string, error) {
+	result := value
+
+	// Expand ${VAR:-default} patterns
+	result = envWithDefaultPattern.ReplaceAllStringFunc(result, func(match string) string {
+		submatches := envWithDefaultPattern.FindStringSubmatch(match)
+		if len(submatches) != 3 {
+			return match
+		}
+		varName := submatches[1]
+		defaultValue := submatches[2]
+
+		if val, ok := os.LookupEnv(varName); ok && val != "" {
+			return val
+		}
+		return defaultValue
+	})
+
+	// Expand ${VAR} patterns (but skip if they contain :-)
+	missingVars := []string{}
+	result = envRequiredPattern.ReplaceAllStringFunc(result, func(match string) string {
+		if regexp.MustCompile(`:-`).MatchString(match) {
+			return match
+		}
+
+		submatches := envRequiredPattern.FindStringSubmatch(match)
+		if len(submatches) != 2 {
+			return match
+		}
+		varName := submatches[1]
+
+		val, ok := os.LookupEnv(varName)
+		if !ok || val == "" {
+			missingVars = append(missingVars, match)
+			return match
+		}
+		return val
+	})
+
+	if len(missingVars) > 0 {
+		return "", fmt.Errorf("required environment variable(s) not set: %v", missingVars)
+	}
+
+	return result, nil
+}
+

--- a/pkg/mcpproxy/env_expand_test.go
+++ b/pkg/mcpproxy/env_expand_test.go
@@ -1,0 +1,146 @@
+package mcpproxy
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		setupEnv    map[string]string
+		expected    string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "simple value no expansion",
+			value:       "simple-value",
+			expected:    "simple-value",
+			expectError: false,
+		},
+		{
+			name:        "required var set",
+			value:       "${TEST_VAR}",
+			setupEnv:    map[string]string{"TEST_VAR": "test-value"},
+			expected:    "test-value",
+			expectError: false,
+		},
+		{
+			name:        "required var not set",
+			value:       "${TEST_VAR}",
+			setupEnv:    map[string]string{},
+			expectError: true,
+			errorMsg:    "required environment variable(s) not set",
+		},
+		{
+			name:        "required var empty",
+			value:       "${TEST_VAR}",
+			setupEnv:    map[string]string{"TEST_VAR": ""},
+			expectError: true,
+			errorMsg:    "required environment variable(s) not set",
+		},
+		{
+			name:        "default var set",
+			value:       "${TEST_VAR:-default-value}",
+			setupEnv:    map[string]string{"TEST_VAR": "actual-value"},
+			expected:    "actual-value",
+			expectError: false,
+		},
+		{
+			name:        "default var not set",
+			value:       "${TEST_VAR:-default-value}",
+			setupEnv:    map[string]string{},
+			expected:    "default-value",
+			expectError: false,
+		},
+		{
+			name:        "default var empty",
+			value:       "${TEST_VAR:-default-value}",
+			setupEnv:    map[string]string{"TEST_VAR": ""},
+			expected:    "default-value",
+			expectError: false,
+		},
+		{
+			name:        "default with empty string",
+			value:       "${TEST_VAR:-}",
+			setupEnv:    map[string]string{},
+			expected:    "",
+			expectError: false,
+		},
+		{
+			name:        "multiple expansions",
+			value:       "${VAR1}-${VAR2:-default}",
+			setupEnv:    map[string]string{"VAR1": "value1"},
+			expected:    "value1-default",
+			expectError: false,
+		},
+		{
+			name:        "mixed required and default",
+			value:       "${REQUIRED_VAR}:${OPTIONAL_VAR:-optional}",
+			setupEnv:    map[string]string{"REQUIRED_VAR": "required"},
+			expected:    "required:optional",
+			expectError: false,
+		},
+		{
+			name:        "nested expansion in default",
+			value:       "${VAR1:-${VAR2:-final-default}}",
+			setupEnv:    map[string]string{},
+			expected:    "final-default",
+			expectError: false,
+		},
+		{
+			name:        "literal dollar sign",
+			value:       "cost: $100",
+			expected:    "cost: $100",
+			expectError: false,
+		},
+		{
+			name:        "multiple required vars one missing",
+			value:       "${VAR1}-${VAR2}",
+			setupEnv:    map[string]string{"VAR1": "value1"},
+			expectError: true,
+			errorMsg:    "required environment variable(s) not set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original env
+			originalEnv := make(map[string]string)
+			for k, v := range tt.setupEnv {
+				if orig, ok := os.LookupEnv(k); ok {
+					originalEnv[k] = orig
+				}
+				os.Setenv(k, v)
+			}
+			defer func() {
+				// Restore original env
+				for k := range tt.setupEnv {
+					if orig, ok := originalEnv[k]; ok {
+						os.Setenv(k, orig)
+					} else {
+						os.Unsetenv(k)
+					}
+				}
+			}()
+
+			result, err := ExpandEnv(tt.value)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+

--- a/pkg/mcpproxy/server_test.go
+++ b/pkg/mcpproxy/server_test.go
@@ -1,0 +1,190 @@
+package mcpproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerEnvForwarding(t *testing.T) {
+	// Build the mock MCP server binary
+	mockServerPath := filepath.Join(t.TempDir(), "mcpEnvDumpTest")
+	
+	// Get the absolute path to the testdata directory
+	_, testFile, _, _ := runtime.Caller(0)
+	testDir := filepath.Dir(testFile)
+	testdataPath := filepath.Join(testDir, "testdata", "mcpEnvDumpTest")
+	
+	buildCmd := exec.Command("go", "build", "-o", mockServerPath, testdataPath)
+	var stderr bytes.Buffer
+	buildCmd.Stderr = &stderr
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("Failed to build mock MCP server: %v\nStderr: %s", err, stderr.String())
+	}
+
+	tests := []struct {
+		name        string
+		env         map[string]string
+		setupEnv    map[string]string // Environment to set before expansion
+		expectedEnv map[string]string // Expected env vars in dump file
+		expectError bool
+	}{
+		{
+			name: "simple env forwarding",
+			env: map[string]string{
+				"TEST_SIMPLE": "simple-value",
+			},
+			expectedEnv: map[string]string{
+				"TEST_SIMPLE": "simple-value",
+			},
+		},
+		{
+			name: "env with expansion default used",
+			env: map[string]string{
+				"TEST_EXPANDED": "${TEST_BASE_URL:-http://localhost:8080}",
+			},
+			setupEnv: map[string]string{},
+			expectedEnv: map[string]string{
+				"TEST_EXPANDED": "http://localhost:8080",
+			},
+		},
+		{
+			name: "env with expansion var set",
+			env: map[string]string{
+				"TEST_EXPANDED": "${TEST_BASE_URL:-http://localhost:8080}",
+			},
+			setupEnv: map[string]string{
+				"TEST_BASE_URL": "http://custom:9090",
+			},
+			expectedEnv: map[string]string{
+				"TEST_EXPANDED": "http://custom:9090",
+			},
+		},
+		{
+			name: "multiple env vars",
+			env: map[string]string{
+				"TEST_VAR1": "value1",
+				"TEST_VAR2": "${TEST_VAR2_DEFAULT:-default2}",
+			},
+			setupEnv: map[string]string{},
+			expectedEnv: map[string]string{
+				"TEST_VAR1": "value1",
+				"TEST_VAR2": "default2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore original env
+			originalEnv := make(map[string]string)
+			for k, v := range tt.setupEnv {
+				if orig, ok := os.LookupEnv(k); ok {
+					originalEnv[k] = orig
+				}
+				os.Setenv(k, v)
+			}
+			defer func() {
+				for k := range tt.setupEnv {
+					if orig, ok := originalEnv[k]; ok {
+						os.Setenv(k, orig)
+					} else {
+						os.Unsetenv(k)
+					}
+				}
+			}()
+
+			// Create temp directory for output file
+			tempDir := t.TempDir()
+			envDumpFile := filepath.Join(tempDir, "env-dump.json")
+
+			// Create server config
+			config := &ServerConfig{
+				Command: mockServerPath,
+				Args:    []string{},
+				Env:     tt.env,
+			}
+
+			// Add ENV_DUMP_FILE to config env
+			if config.Env == nil {
+				config.Env = make(map[string]string)
+			}
+			config.Env["ENV_DUMP_FILE"] = envDumpFile
+
+			// Create context with timeout
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			// Create and start server
+			server, err := NewProxyServerForConfig(ctx, "mcpEnvDumpTest", config)
+			if err != nil {
+				// Note: stderr from the MCP server process is automatically included
+				// in the error message from NewProxyServerForConfig
+				t.Fatalf("Failed to create server (failed checking environment variables?): %v", err)
+			}
+
+			// Start server in background
+			serverErr := make(chan error, 1)
+			go func() {
+				serverErr <- server.Run(ctx)
+			}()
+
+			// Wait for server to be ready
+			err = server.WaitReady(ctx)
+			require.NoError(t, err, "Server failed to become ready")
+
+			// Wait for the initialize request to be processed and file to be written
+			// The MCP client automatically sends initialize when connecting, so we just need to wait
+			maxWait := 5 * time.Second
+			checkInterval := 100 * time.Millisecond
+			waited := time.Duration(0)
+			for waited < maxWait {
+				if _, err := os.Stat(envDumpFile); err == nil {
+					// File exists, give it a moment to be fully written
+					time.Sleep(100 * time.Millisecond)
+					break
+				}
+				time.Sleep(checkInterval)
+				waited += checkInterval
+			}
+
+			// Read and verify the env dump file
+			data, err := os.ReadFile(envDumpFile)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err, "Failed to read env dump file")
+			require.NotEmpty(t, data, "Env dump file is empty")
+
+			var dumpedEnv map[string]string
+			err = json.Unmarshal(data, &dumpedEnv)
+			require.NoError(t, err, "Failed to parse env dump file")
+
+			// Verify expected env vars are present
+			for key, expectedValue := range tt.expectedEnv {
+				actualValue, ok := dumpedEnv[key]
+				assert.True(t, ok, "Expected env var %s not found in dump", key)
+				assert.Equal(t, expectedValue, actualValue, "Env var %s has wrong value", key)
+			}
+
+			// Verify ENV_DUMP_FILE is present
+			assert.Contains(t, dumpedEnv, "ENV_DUMP_FILE", "ENV_DUMP_FILE should be in dump")
+
+			// Clean up
+			cancel()
+			server.Close()
+		})
+	}
+}
+

--- a/pkg/mcpproxy/testdata/mcpEnvDumpTest/main.go
+++ b/pkg/mcpproxy/testdata/mcpEnvDumpTest/main.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type JSONRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type JSONRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *JSONRPCError   `json:"error,omitempty"`
+}
+
+type JSONRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type InitializeResult struct {
+	ProtocolVersion string     `json:"protocolVersion"`
+	Capabilities    struct{}   `json:"capabilities"`
+	ServerInfo      ServerInfo `json:"serverInfo"`
+}
+
+type ServerInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+func main() {
+	// Get the output file path from environment
+	envDumpFile := os.Getenv("ENV_DUMP_FILE")
+	if envDumpFile == "" {
+		fmt.Fprintf(os.Stderr, "ENV_DUMP_FILE environment variable not set\n")
+		os.Exit(1)
+	}
+
+	// Read JSON-RPC requests from stdin
+	scanner := bufio.NewScanner(os.Stdin)
+	encoder := json.NewEncoder(os.Stdout)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		var req JSONRPCRequest
+		if err := json.Unmarshal([]byte(line), &req); err != nil {
+			// Invalid JSON, skip
+			continue
+		}
+
+		// Handle initialize request
+		if req.Method == "initialize" {
+			// Dump environment variables filtered by TEST_ prefix
+			envVars := make(map[string]string)
+			for _, env := range os.Environ() {
+				parts := strings.SplitN(env, "=", 2)
+				if len(parts) == 2 {
+					key := parts[0]
+					value := parts[1]
+					// Filter by TEST_ prefix or specific vars we care about
+					if strings.HasPrefix(key, "TEST_") || key == "ENV_DUMP_FILE" {
+						envVars[key] = value
+					}
+				}
+			}
+
+			// Write to file
+			data, err := json.MarshalIndent(envVars, "", "  ")
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to marshal env vars: %v\n", err)
+				continue
+			}
+
+			if err := os.WriteFile(envDumpFile, data, 0644); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to write env dump file: %v\n", err)
+				continue
+			}
+
+			// Send initialize response
+			result := InitializeResult{
+				ProtocolVersion: "2024-11-05",
+				ServerInfo: ServerInfo{
+					Name:    "mcpEnvDumpTest",
+					Version: "1.0.0",
+				},
+			}
+
+			resultJSON, _ := json.Marshal(result)
+			response := JSONRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result:  resultJSON,
+			}
+
+			if err := encoder.Encode(response); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to encode response: %v\n", err)
+			}
+		} else {
+			// For other methods, send a simple response
+			response := JSONRPCResponse{
+				JSONRPC: "2.0",
+				ID:      req.ID,
+				Result:  json.RawMessage("{}"),
+			}
+			if err := encoder.Encode(response); err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to encode response: %v\n", err)
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading stdin: %v\n", err)
+		os.Exit(1)
+	}
+}
+


### PR DESCRIPTION
The `env` configuration of `mcpServers:` was not forwarded to the process itself.
Not sure if we should add this mini-mcpServer for testing.
Looking forward for comments on this