### PR TITLE
Support 'assertions' also in tasks yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,10 @@ config:
       modelNameKey: JUDGE_MODEL_NAME # Env var name for model name
   taskSets:
     - path: tasks/create-pod.yaml
-      assertions:
-        toolsUsed:
-          - server: kubernetes
-            toolPattern: "pods_.*"  # Agent must use pod-related tools
-        minToolCalls: 1
-        maxToolCalls: 10
+      # Assertions can be in eval.yaml (here)
+      # or in tasks/*.yaml
+      assertions: # Full syntax in the "Assertions" section
+        …
 ```
 
 **mcp-config.yaml** - MCP server to test:
@@ -93,14 +91,18 @@ steps:
     file: cleanup.sh    # Deletes pod
   prompt:
     inline: Create a nginx pod named web-server in the test-namespace
+  assertions:           # Full syntax in the "Assertions" section
+    …
 ```
 
 Note: You must choose either script-based verification (`file` or `inline`) OR LLM judge verification (`contains` or `exact`), not both.
 
 ## Assertions
 
-Validate agent behavior:
+Assertions validate agent behavior and should be defined in the task file or in the eval file.
+When both are present, task assertions take precedence and a warning is printed.
 
+**In tasks/*.yaml or eval.yaml:**
 ```yaml
 assertions:
   # Must call these tools
@@ -149,6 +151,20 @@ assertions:
   # No duplicate calls
   noDuplicateCalls: true
 ```
+
+**In eval.yaml:**
+```yaml
+taskSets:
+  - path: tasks/create-pod.yaml
+    assertions:
+      toolsUsed:
+        - server: kubernetes
+          tool: pods_create
+      minToolCalls: 1
+      maxToolCalls: 10
+```
+
+**Note:** If assertions are defined in both places, task.yaml assertions take precedence and a warning is printed.
 
 ## Test Scripts
 

--- a/examples/kube-mcp-server/claude-code/eval.yaml
+++ b/examples/kube-mcp-server/claude-code/eval.yaml
@@ -11,9 +11,3 @@ config:
       modelNameKey: JUDGE_MODEL_NAME
   taskSets:
     - glob: ../tasks/*/*.yaml
-      assertions:
-        toolsUsed:
-          - server: kubernetes
-            toolPattern: ".*"
-        minToolCalls: 1
-        maxToolCalls: 20

--- a/examples/kube-mcp-server/openai-agent/eval.yaml
+++ b/examples/kube-mcp-server/openai-agent/eval.yaml
@@ -11,9 +11,3 @@ config:
       modelNameKey: JUDGE_MODEL_NAME
   taskSets:
     - glob: ../tasks/*/*.yaml
-      assertions:
-        toolsUsed:
-          - server: kubernetes
-            toolPattern: ".*"
-        minToolCalls: 1
-        maxToolCalls: 20

--- a/examples/kube-mcp-server/tasks/create-pod/create-pod.yaml
+++ b/examples/kube-mcp-server/tasks/create-pod/create-pod.yaml
@@ -11,3 +11,9 @@ steps:
     file: cleanup.sh
   prompt:
     inline: Please create a nginx pod named web-server in the create-pod-test namespace
+  assertions:
+    toolsUsed:
+      - server: kubernetes
+        toolPattern: ".*"
+    minToolCalls: 1
+    maxToolCalls: 20

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -121,6 +121,9 @@ func (d *progressDisplay) handleProgress(event eval.ProgressEvent) {
 			fmt.Printf("  → Evaluating assertions...\n")
 		}
 
+	case eval.EventWarning:
+		d.yellow.Printf("  ⚠ Warning: %s\n", event.Message)
+
 	case eval.EventTaskError:
 		task := event.Task
 		d.red.Printf("  ✗ Task failed during setup\n")

--- a/pkg/eval/progress.go
+++ b/pkg/eval/progress.go
@@ -23,6 +23,7 @@ const (
 	EventTaskComplete   ProgressEventType = "task_complete"
 	EventTaskError      ProgressEventType = "task_error"
 	EventEvalComplete   ProgressEventType = "eval_complete"
+	EventWarning        ProgressEventType = "warning"
 )
 
 // NoopProgressCallback is a progress callback that does nothing

--- a/pkg/task/config.go
+++ b/pkg/task/config.go
@@ -32,11 +32,69 @@ type TaskSteps struct {
 	CleanupScript *util.Step  `json:"cleanup,omitempty"`
 	VerifyScript  *VerifyStep `json:"verify,omitempty"`
 	Prompt        *util.Step  `json:"prompt,omitempty"`
+	Assertions    *TaskAssertions `json:"assertions,omitempty"`
 }
 
 type VerifyStep struct {
 	*util.Step
 	*llmjudge.LLMJudgeTaskConfig
+}
+
+// TaskAssertions defines assertions for a task (duplicated from eval package to avoid circular dependency)
+type TaskAssertions struct {
+	// Tool assertions
+	ToolsUsed    []ToolAssertion `json:"toolsUsed,omitempty"`
+	RequireAny   []ToolAssertion `json:"requireAny,omitempty"`
+	ToolsNotUsed []ToolAssertion `json:"toolsNotUsed,omitempty"`
+	MinToolCalls *int            `json:"minToolCalls,omitempty"`
+	MaxToolCalls *int            `json:"maxToolCalls,omitempty"`
+
+	// Resource assertions
+	ResourcesRead    []ResourceAssertion `json:"resourcesRead,omitempty"`
+	ResourcesNotRead []ResourceAssertion `json:"resourcesNotRead,omitempty"`
+
+	// Prompt assertions
+	PromptsUsed    []PromptAssertion `json:"promptsUsed,omitempty"`
+	PromptsNotUsed []PromptAssertion `json:"promptsNotUsed,omitempty"`
+
+	// Order assertions
+	CallOrder []CallOrderAssertion `json:"callOrder,omitempty"`
+
+	// Efficiency assertions
+	NoDuplicateCalls bool `json:"noDuplicateCalls,omitempty"`
+}
+
+type ToolAssertion struct {
+	Server string `json:"server"`
+
+	// Exactly one of Tool or ToolPattern should be set
+	// If neither is set, matches any tool from the server
+	Tool        string `json:"tool,omitempty"`
+	ToolPattern string `json:"toolPattern,omitempty"` // regex pattern
+}
+
+type ResourceAssertion struct {
+	Server string `json:"server"`
+
+	// Exactly one of URI or URIPattern should be set
+	// If neither is set, matches any resource from the server
+	URI        string `json:"uri,omitempty"`
+	URIPattern string `json:"uriPattern,omitempty"` // regex pattern
+}
+
+type PromptAssertion struct {
+	Server string `json:"server"`
+
+	// Exactly one of Prompt or PromptPattern should be set
+	// If neither is set, matches any prompt from the server
+	Prompt        string `json:"prompt,omitempty"`
+	PromptPattern string `json:"promptPattern,omitempty"`
+}
+
+type CallOrderAssertion struct {
+	Type   string `json:"type"` // "tool", "resource", "prompt"
+	Server string `json:"server"`
+	Name   string `json:"name"`
 }
 
 func (v *VerifyStep) IsEmpty() bool {


### PR DESCRIPTION
This is probably more controversial, so I'll mark it as draft, although this should work as is.

For me it seems more straight forward to have the assertions next to the `prompt`
as if the prompt changes, I would need to change the assertions too?

please help me understand what the rational was to have `prompt` and `assertions` in separate files
