### PR TITLE
fix: awk scripts in action handle unset vars

### DIFF
--- a/.github/actions/gevals-action/action.yaml
+++ b/.github/actions/gevals-action/action.yaml
@@ -352,9 +352,10 @@ runs:
 
             # Calculate pass rates using awk (handles division-by-zero)
             # Note: awk is used instead of bc for better portability across platforms,
-            # especially on Windows runners where bc may not be available
-            TASK_PASS_RATE=$(awk -v total="$TOTAL_TASKS" -v passed="$TASKS_PASSED" 'BEGIN {printf "%.4f", total > 0 ? passed / total : 0}')
-            ASSERTION_PASS_RATE=$(awk -v total="$TOTAL_ASSERTIONS" -v passed="$ASSERTIONS_PASSED" 'BEGIN {printf "%.4f", total > 0 ? passed / total : 0}')
+            # especially on Windows runners where bc may not be available.
+            # Uses if-else instead of ternary operator for BSD awk (macOS) compatibility.
+            TASK_PASS_RATE=$(awk -v total="$TOTAL_TASKS" -v passed="$TASKS_PASSED" 'BEGIN {if (total > 0) printf "%.4f", passed / total; else printf "%.4f", 0}')
+            ASSERTION_PASS_RATE=$(awk -v total="$TOTAL_ASSERTIONS" -v passed="$ASSERTIONS_PASSED" 'BEGIN {if (total > 0) printf "%.4f", passed / total; else printf "%.4f", 0}')
 
             # Output metrics
             echo "tasks-total=$TOTAL_TASKS" >> $GITHUB_OUTPUT
@@ -368,8 +369,8 @@ runs:
             TASK_THRESHOLD="${{ inputs.task-pass-threshold }}"
             ASSERTION_THRESHOLD="${{ inputs.assertion-pass-threshold }}"
 
-            TASK_THRESHOLD_MET=$(awk -v rate="$TASK_PASS_RATE" -v threshold="$TASK_THRESHOLD" 'BEGIN {print (rate >= threshold ? 1 : 0)}')
-            ASSERTION_THRESHOLD_MET=$(awk -v rate="$ASSERTION_PASS_RATE" -v threshold="$ASSERTION_THRESHOLD" 'BEGIN {print (rate >= threshold ? 1 : 0)}')
+            TASK_THRESHOLD_MET=$(awk -v rate="$TASK_PASS_RATE" -v threshold="$TASK_THRESHOLD" 'BEGIN {if (rate >= threshold) print 1; else print 0}')
+            ASSERTION_THRESHOLD_MET=$(awk -v rate="$ASSERTION_PASS_RATE" -v threshold="$ASSERTION_THRESHOLD" 'BEGIN {if (rate >= threshold) print 1; else print 0}')
 
             if [ "$TASK_THRESHOLD_MET" -eq 1 ] && [ "$ASSERTION_THRESHOLD_MET" -eq 1 ]; then
               THRESHOLDS_PASSED="true"


### PR DESCRIPTION
This PR improves the robustness of the awk commands we were running, by:
1. Using if-else instead of ternary as BSD awk (macos) does not support ternary operator
2. Passes variables to awk using `-v` to handle unset variables properly (should fix https://github.com/containers/kubernetes-mcp-server/issues/526)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gevals-action compatibility with macOS and BSD systems through enhanced calculation logic for pass rates and threshold validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->