### PR TITLE
fix: changelog extraction does not contain extra info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fixed release changelog extraction logic
 
 ## [0.0.1]
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ release: build-release package-release sign-release
 # Changelog extraction targets
 .PHONY: extract-changelog-unreleased
 extract-changelog-unreleased:
-	@echo "Extracting unreleased changelog section..."
+	@echo "Extracting unreleased changelog section..." >&2
 	@CHANGELOG_CONTENT=$$(sed -n '/## \[Unreleased\]/,/## \[/p' CHANGELOG.md | $(CHANGELOG_PIPELINE)); \
 	if [ -z "$$CHANGELOG_CONTENT" ]; then \
 		CHANGELOG_CONTENT="See CHANGELOG.md for details."; \
@@ -84,7 +84,7 @@ extract-changelog-version:
 		echo "Error: VERSION is required. Usage: make extract-changelog-version VERSION=v1.0.0"; \
 		exit 1; \
 	fi
-	@echo "Extracting changelog for version $(VERSION)..."
+	@echo "Extracting changelog for version $(VERSION)..." >&2
 	@VERSION_NO_V=$$(echo "$(VERSION)" | sed 's/^v//'); \
 	CHANGELOG_CONTENT=$$(sed -n "/## \[$${VERSION_NO_V}\]/,/## \[/p" CHANGELOG.md | $(CHANGELOG_PIPELINE)); \
 	if [ -z "$$CHANGELOG_CONTENT" ]; then \


### PR DESCRIPTION
When cutting a v0.0.1 release candidate I realized that the "Extracting ..." text was being included in the release notes.

This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release changelog extraction logic

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->