### PR TITLE
fix: release workflows create releases whenever tagged

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -19,7 +19,6 @@ jobs:
     outputs:
       prerelease_version: ${{ env.PRERELEASE_VERSION }}
       changelog_body: ${{ env.CHANGELOG_BODY }}
-      has_new_commits: ${{ steps.check_commits.outputs.HAS_NEW_COMMITS }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -42,12 +41,7 @@ jobs:
           echo "PRERELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "Pre-release version: $VERSION"
 
-      - name: Check for new commits since last release
-        id: check_commits
-        run: make check-commits-since-release
-
       - name: Extract changelog
-        if: steps.check_commits.outputs.HAS_NEW_COMMITS == 'true'
         id: changelog
         run: |
           VERSION="${{ env.PRERELEASE_VERSION }}"
@@ -65,7 +59,6 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Create or update pre-release
-        if: steps.check_commits.outputs.HAS_NEW_COMMITS == 'true'
         run: |
           VERSION="${{ env.PRERELEASE_VERSION }}"
 
@@ -96,7 +89,6 @@ jobs:
 
   build-and-upload:
     needs: determine-version
-    if: needs.determine-version.outputs.has_new_commits == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,6 @@ jobs:
     outputs:
       version: ${{ env.VERSION }}
       changelog_body: ${{ env.CHANGELOG_BODY }}
-      has_new_commits: ${{ steps.check_commits.outputs.HAS_NEW_COMMITS }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -46,12 +45,7 @@ jobs:
       - name: Validate CHANGELOG has version section
         run: make validate-changelog-has-version VERSION="${{ env.VERSION }}"
 
-      - name: Check for new commits since last release
-        id: check_commits
-        run: make check-commits-since-release
-
       - name: Extract changelog for release
-        if: steps.check_commits.outputs.HAS_NEW_COMMITS == 'true'
         id: changelog
         run: |
           VERSION="${{ env.VERSION }}"
@@ -66,14 +60,12 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Run tests
-        if: steps.check_commits.outputs.HAS_NEW_COMMITS == 'true'
         run: |
           echo "Running all tests..."
           go test ./...
           echo "All tests passed!"
 
       - name: Create or update release
-        if: steps.check_commits.outputs.HAS_NEW_COMMITS == 'true'
         run: |
           VERSION="${{ env.VERSION }}"
 
@@ -104,7 +96,6 @@ jobs:
 
   build-and-upload:
     needs: determine-version
-    if: needs.determine-version.outputs.has_new_commits == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/Makefile
+++ b/Makefile
@@ -179,34 +179,3 @@ upload-release-assets:
 	done
 	@echo "✓ All assets uploaded successfully"
 
-# Check if there are new commits since the latest release
-# Outputs: HAS_NEW_COMMITS=true/false to GITHUB_OUTPUT (in CI) or stdout (locally)
-# Used by CI to prevent creating releases when there's nothing new to release
-.PHONY: check-commits-since-release
-check-commits-since-release:
-	@echo "Checking for commits since latest release..."
-	@LATEST_RELEASE=$$(git tag -l 'v*.*.*' --sort=-version:refname | grep -vE '\-rc' | grep -v '^nightly' | head -n1); \
-	if [ -z "$$LATEST_RELEASE" ]; then \
-		echo "No existing releases found"; \
-		COMMITS_SINCE_RELEASE=$$(git rev-list HEAD --count); \
-	else \
-		echo "Latest release: $$LATEST_RELEASE"; \
-		COMMITS_SINCE_RELEASE=$$(git rev-list $${LATEST_RELEASE}..HEAD --count); \
-	fi; \
-	echo "Commits since latest release: $$COMMITS_SINCE_RELEASE"; \
-	if [ "$$COMMITS_SINCE_RELEASE" -eq "0" ]; then \
-		echo "No new commits since latest release - skipping release"; \
-		if [ -n "$$GITHUB_OUTPUT" ]; then \
-			echo "HAS_NEW_COMMITS=false" >> "$$GITHUB_OUTPUT"; \
-		else \
-			echo "HAS_NEW_COMMITS=false"; \
-		fi; \
-	else \
-		echo "Found new commits - proceeding with release"; \
-		if [ -n "$$GITHUB_OUTPUT" ]; then \
-			echo "HAS_NEW_COMMITS=true" >> "$$GITHUB_OUTPUT"; \
-		else \
-			echo "HAS_NEW_COMMITS=true"; \
-		fi; \
-	fi
-


### PR DESCRIPTION
Currently, creating a new release fails due to the check to see if there are any commits since the last tag, as we actually manually trigger releases through tagging.

This is because during the process of creating the release automation we switched from automatically running this against a branch to running this when tags are created.

This PR cleans up the release workflows by removing the check. The assumption now is that if someone creates a tag they meant to make the release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Simplified release and pre-release workflows by removing commit-based conditional checks
  * Release processes now consistently execute changelog extraction, testing, and release creation steps without gating logic
  * Improved workflow reliability across all release scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->