### PR TITLE
fix: release tests should run now

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -134,7 +134,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -104,7 +104,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,11 @@ jobs:
       - name: Validate CHANGELOG has version section
         run: make validate-changelog-has-version VERSION="${{ env.VERSION }}"
 
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
       - name: Extract changelog for release
         id: changelog
         run: |
@@ -111,7 +116,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/genmcp/gevals
 
-go 1.24.4
+go 1.24.10
 
 require (
 	github.com/fatih/color v1.18.0


### PR DESCRIPTION
This PR continues to work towards having a working release pipeline, and fixes the test runner.

It seems like the tests failed to run, in particular the `agent` package does not run. This led to the release action failing.

This PR adds a setup-go step to the release pipeline, and updates the go version as go versions before 1.24.8 are affected with a CVE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to use newer Go toolchain version, improving build stability and performance across all deployment pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->