### PR TITLE
feat: add Claude Code agent for net-edge evals

### DIFF
--- a/examples/net-edge/README.md
+++ b/examples/net-edge/README.md
@@ -11,10 +11,12 @@ net-edge/
 ├── mcp-config.yaml                   # Launches the gen-mcp NetEdge server for gevals
 ├── codex-agent/
 │   ├── agent.yaml                    # Codex CLI wiring
-│   └── eval.yaml                     # Eval definition (scenario 1)
+│   └── eval_*.yaml                   # Eval definitions
 ├── gemini-agent/
 │   ├── agent.yaml                    # Gemini CLI wiring
 │   └── eval_*.yaml                   # Eval definitions
+├── claude-code-agent/
+│   └── eval_*.yaml                   # Eval definitions (uses builtin claude-code agent)
 └── tasks/
     └── selector-mismatch/            # Task definition and helper scripts
         ├── selector-mismatch.yaml
@@ -68,7 +70,7 @@ export OPENAI_API_KEY=sk-...
 4. Run the evaluation:
 
  ```bash
- ./gevals eval examples/net-edge/codex-agent/eval.yaml
+ ./gevals eval examples/net-edge/codex-agent/eval_1_selector-mismatch.yaml
  ```
 
 ## Running with Gemini
@@ -80,6 +82,18 @@ export OPENAI_API_KEY=sk-...
 
  ```bash
  ./gevals eval examples/net-edge/gemini-agent/eval_1_selector-mismatch.yaml
+ ```
+
+## Running with Claude Code
+
+1. Build the project (from repo root): `make build`
+2. Ensure `claude` CLI is in your `PATH`.
+3. Ensure your current shell can reach the OpenShift cluster (`oc whoami` should succeed).
+4. Ensure `ANTHROPIC_API_KEY` environment variable is set.
+5. Run the evaluation:
+
+ ```bash
+ ./gevals eval examples/net-edge/claude-code-agent/eval_1_selector-mismatch.yaml
  ```
 
 `setup.sh` deploys the hello workload, then intentionally breaks the Service selector so the Route loses its

--- a/examples/net-edge/claude-code-agent/eval_1_selector-mismatch.yaml
+++ b/examples/net-edge/claude-code-agent/eval_1_selector-mismatch.yaml
@@ -1,0 +1,14 @@
+kind: Eval
+metadata:
+  name: "claude-code-netedge-selector-mismatch"
+config:
+  agent:
+    type: "builtin.claude-code"
+  mcpConfigFile: ../mcp-config.yaml
+  taskSets:
+    - path: ../tasks/selector-mismatch/selector-mismatch.yaml
+      assertions:
+        toolsUsed:
+          - server: netedge
+        minToolCalls: 1
+        maxToolCalls: 20

--- a/examples/net-edge/claude-code-agent/eval_2_nxdomain.yaml
+++ b/examples/net-edge/claude-code-agent/eval_2_nxdomain.yaml
@@ -1,0 +1,14 @@
+kind: Eval
+metadata:
+  name: "claude-code-netedge-nxdomain-host"
+config:
+  agent:
+    type: "builtin.claude-code"
+  mcpConfigFile: ../mcp-config.yaml
+  taskSets:
+    - path: ../tasks/nxdomain-host/nxdomain-host.yaml
+      assertions:
+        toolsUsed:
+          - server: netedge
+        minToolCalls: 1
+        maxToolCalls: 20

--- a/examples/net-edge/claude-code-agent/eval_3_networkpolicy.yaml
+++ b/examples/net-edge/claude-code-agent/eval_3_networkpolicy.yaml
@@ -1,0 +1,14 @@
+kind: Eval
+metadata:
+  name: "claude-code-netedge-networkpolicy-block"
+config:
+  agent:
+    type: "builtin.claude-code"
+  mcpConfigFile: ../mcp-config.yaml
+  taskSets:
+    - path: ../tasks/networkpolicy-block/networkpolicy-block.yaml
+      assertions:
+        toolsUsed:
+          - server: netedge
+        minToolCalls: 1
+        maxToolCalls: 20

--- a/examples/net-edge/claude-code-agent/eval_4_reencrypt-tls.yaml
+++ b/examples/net-edge/claude-code-agent/eval_4_reencrypt-tls.yaml
@@ -1,0 +1,14 @@
+kind: Eval
+metadata:
+  name: "claude-code-netedge-reencrypt-no-backend-tls"
+config:
+  agent:
+    type: "builtin.claude-code"
+  mcpConfigFile: ../mcp-config.yaml
+  taskSets:
+    - path: ../tasks/reencrypt-no-backend-tls/reencrypt-no-backend-tls.yaml
+      assertions:
+        toolsUsed:
+          - server: netedge
+        minToolCalls: 1
+        maxToolCalls: 20

--- a/examples/net-edge/claude-code-agent/eval_5_loadbalancer.yaml
+++ b/examples/net-edge/claude-code-agent/eval_5_loadbalancer.yaml
@@ -1,0 +1,14 @@
+kind: Eval
+metadata:
+  name: "claude-code-netedge-loadbalancer-missing"
+config:
+  agent:
+    type: "builtin.claude-code"
+  mcpConfigFile: ../mcp-config.yaml
+  taskSets:
+    - path: ../tasks/loadbalancer-missing/loadbalancer-missing.yaml
+      assertions:
+        toolsUsed:
+          - server: netedge
+        minToolCalls: 1
+        maxToolCalls: 20

--- a/examples/net-edge/mcp-config.yaml
+++ b/examples/net-edge/mcp-config.yaml
@@ -5,4 +5,6 @@ mcpServers:
       - run
       - -f
       - ../gen-mcp/examples/netedge-tools/mcpfile.yaml
+      - -s
+      - ../gen-mcp/examples/netedge-tools/mcpserver.yaml
     enableAllTools: true

--- a/pkg/agent/claude_code.go
+++ b/pkg/agent/claude_code.go
@@ -29,16 +29,18 @@ func (a *ClaudeCodeAgent) ValidateEnvironment() error {
 func (a *ClaudeCodeAgent) GetDefaults(model string) (*AgentSpec, error) {
 	separator := ","
 	useVirtualHome := false
+	dangerouslySkipPermissions := false
 	return &AgentSpec{
 		Metadata: AgentMetadata{
 			Name: "claude-code",
 		},
 		Commands: AgentCommands{
-			UseVirtualHome:            &useVirtualHome,
-			ArgTemplateMcpServer:      "--mcp-config {{ .File }}",
-			ArgTemplateAllowedTools:   "mcp__{{ .ServerName }}__{{ .ToolName }}",
-			AllowedToolsJoinSeparator: &separator,
-			RunPrompt:                 `claude {{ .McpServerFileArgs }} --strict-mcp-config --allowedTools "{{ .AllowedToolArgs }}" --print "{{ .Prompt }}"`,
+			UseVirtualHome:             &useVirtualHome,
+			ArgTemplateMcpServer:       "--mcp-config {{ .File }}",
+			ArgTemplateAllowedTools:    "mcp__{{ .ServerName }}__{{ .ToolName }}",
+			AllowedToolsJoinSeparator:  &separator,
+			DangerouslySkipPermissions: &dangerouslySkipPermissions,
+			RunPrompt:                  `claude {{ .McpServerFileArgs }} --strict-mcp-config --allowedTools "{{ .AllowedToolArgs }}" -p "{{ .Prompt }}"{{ if .DangerouslySkipPermissions }} --dangerously-skip-permissions{{ end }} --output-format stream-json --verbose`,
 		},
 	}, nil
 }

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -64,7 +64,12 @@ type AgentCommands struct {
 	// the prompt will be in {{ .Prompt }}
 	// the servers will be in {{ .McpServerFileArgs }}
 	// the allowed tools will be in {{ .AllowedToolArgs }}
+	// {{ .DangerouslySkipPermissions }} will be true if the flag should be included
 	RunPrompt string `json:"runPrompt"`
+
+	// Whether to skip permission prompts (unsafe, use only for automated testing)
+	// Defaults to false. When true, agents may include flags like --dangerously-skip-permissions
+	DangerouslySkipPermissions *bool `json:"dangerouslySkipPermissions,omitempty"`
 
 	// An optional command to get the version of the agent
 	// useful for generic agents such as claude code that may autoupdate/have different versions on different machines

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -169,14 +169,22 @@ func (a *agentSpecRunner) RunTask(ctx context.Context, prompt string) (AgentResu
 		allowedToolsSeparator = *a.Commands.AllowedToolsJoinSeparator
 	}
 
+	// Default to false if not specified
+	dangerouslySkipPermissions := false
+	if a.Commands.DangerouslySkipPermissions != nil {
+		dangerouslySkipPermissions = *a.Commands.DangerouslySkipPermissions
+	}
+
 	tmp := struct {
-		McpServerFileArgs string
-		AllowedToolArgs   string
-		Prompt            string
+		McpServerFileArgs          string
+		AllowedToolArgs            string
+		Prompt                     string
+		DangerouslySkipPermissions bool
 	}{
-		McpServerFileArgs: strings.Join(serverFiles, " "),
-		AllowedToolArgs:   strings.Join(allowedTools, allowedToolsSeparator),
-		Prompt:            prompt,
+		McpServerFileArgs:          strings.Join(serverFiles, " "),
+		AllowedToolArgs:            strings.Join(allowedTools, allowedToolsSeparator),
+		Prompt:                     prompt,
+		DangerouslySkipPermissions: dangerouslySkipPermissions,
 	}
 
 	formatted := bytes.NewBuffer(nil)


### PR DESCRIPTION
feat: Use builtin claude-code agent for net-edge evals
Summary:

  - Add Claude Code agent configuration for running NetEdge eval scenarios
  - Include 5 eval definitions matching the Gemini agent structure. 6th eval needs more investigation
  - Update README

 Assisted with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for running evaluations with a Claude Code agent and pattern-based eval files.
  * Added several Claude Code evaluation profiles covering common net-edge scenarios.
  * Optional skip-permissions flag for agent runs.

* **Documentation**
  * README updated with "Running with Claude Code" steps and example evaluation commands; parity added alongside existing agent workflows.

* **Chores**
  * Server config accepts an additional server input flag for evaluation runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->