### PR TITLE
fix(action): update Go version to 1.25.x

### DIFF
--- a/.github/actions/gevals-action/action.yaml
+++ b/.github/actions/gevals-action/action.yaml
@@ -161,7 +161,7 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24.x'
+        go-version: '1.25.x'
         cache: false
 
     - name: Install gevals


### PR DESCRIPTION
The project requires Go 1.25.0 (per go.mod), but the action was still using Go 1.24.x. This caused build failures with exit code 2 when consumers used gevals-version: 'latest' to build from source.

See https://github.com/containers/kubernetes-mcp-server/actions/runs/21131724467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development infrastructure to use a newer toolchain version for CI/CD processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->