### PR TITLE
feat(functional): add in-process execution mode for coverage and debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,14 @@ _build-mock-agent:
 functional: build _build-mock-agent ## Run functional tests
 	MCPCHECKER_BINARY=$(CURDIR)/mcpchecker MOCK_AGENT_BINARY=$(CURDIR)/$(MOCK_AGENT_BINARY_NAME) go test -v -tags functional ./functional/...
 
+.PHONY: functional-coverage
+functional-coverage: clean _build-mock-agent ## Run functional tests with coverage (in-process mode)
+	MCPCHECKER_TEST_INPROCESS=true \
+	MOCK_AGENT_BINARY=$(CURDIR)/$(MOCK_AGENT_BINARY_NAME) \
+	go test -v -tags functional -cover -coverprofile=$(CURDIR)/coverage.out -coverpkg=./pkg/...,./cmd/... ./functional/... -p=1
+	go tool cover -html=$(CURDIR)/coverage.out -o=$(CURDIR)/coverage.html
+	@echo "Coverage report: $(CURDIR)/coverage.html"
+
 # Release targets for CI/CD
 .PHONY: build-release
 build-release:

--- a/functional/README.md
+++ b/functional/README.md
@@ -1,0 +1,150 @@
+# Functional Tests
+
+This directory contains functional tests that exercise the `mcpchecker` binary against mock MCP servers, agents, and LLM judges.
+
+## Running Tests
+
+### Subprocess Mode (Default)
+
+Run functional tests using the compiled `mcpchecker` binary as a subprocess:
+
+```bash
+make functional
+```
+
+This builds the `mcpchecker` binary and runs all functional tests against it.
+
+### In-Process Mode (Coverage & Debugging)
+
+Run functional tests in-process to enable code coverage collection and IDE debugging:
+
+```bash
+make functional-coverage
+```
+
+This produces a coverage report at `coverage.html` showing which production code lines are covered by functional tests.
+
+#### IDE Debugging
+
+To debug a specific test with breakpoints in production code:
+
+```bash
+MCPCHECKER_TEST_INPROCESS=true go test -v -tags functional ./functional/tests -run TestTaskPassesWithToolCallAndJudge
+```
+
+Set breakpoints in `pkg/cli/`, `pkg/eval/`, etc. and they will be hit during test execution.
+
+## Writing Functional Tests
+
+Functional tests use a fluent API defined in `functional/testcase/`. Here's a basic example:
+
+```go
+//go:build functional
+
+package tests
+
+import (
+    "testing"
+    "github.com/mcpchecker/mcpchecker/functional/testcase"
+)
+
+func TestMyFeature(t *testing.T) {
+    testcase.New(t, "my-test-case").
+        // Configure mock MCP server with tools
+        WithMCPServer("my-server", func(s *testcase.MCPServerBuilder) {
+            s.Tool("my_tool", func(tool *testcase.ToolDef) {
+                tool.WithDescription("Does something useful").
+                    WithStringParam("param", "A parameter", true).
+                    ReturnsText("success")
+            })
+        }).
+        // Configure mock agent behavior
+        WithAgent(func(a *testcase.AgentBuilder) {
+            a.OnPromptContaining("do something").
+                CallTool("my_tool", map[string]any{"param": "value"}).
+                ThenRespond("I did the thing successfully.")
+        }).
+        // Configure mock LLM judge (optional)
+        WithJudge(func(j *testcase.JudgeBuilder) {
+            j.Always().Pass("Task completed successfully")
+        }).
+        // Configure task
+        AddTask(func(task *testcase.TaskConfig) {
+            task.Name("my-task").
+                Easy().
+                Prompt("Do something with my_tool").
+                VerifyContains("success")
+        }).
+        // Configure eval
+        WithEval(func(eval *testcase.EvalConfig) {
+            eval.Name("my-eval")
+        }).
+        // Add assertions
+        ExpectTaskPassed().
+        ExpectToolCalled("my-server", "my_tool").
+        ExpectJudgeCalled().
+        // Run the test
+        Run()
+}
+```
+
+### Per-Test In-Process Mode
+
+Force a specific test to run in-process (useful for debugging):
+
+```go
+testcase.New(t, "debug-this-test").
+    WithInProcess().  // Force in-process execution
+    WithMCPServer(...).
+    Run()
+```
+
+## Directory Structure
+
+```
+functional/
+├── README.md              # This file
+├── servers/
+│   ├── agent/             # Mock agent implementation
+│   │   └── cmd/           # Mock agent binary
+│   ├── mcp/               # Mock MCP server
+│   └── openai/            # Mock OpenAI API (for LLM judge)
+├── testcase/
+│   ├── case.go            # TestCase fluent API
+│   ├── run.go             # Test runner (subprocess & in-process)
+│   ├── inprocess.go       # In-process executor
+│   ├── assertions.go      # Test assertions
+│   ├── builders.go        # Mock server builders
+│   └── generator.go       # Config file generation
+└── tests/
+    └── happy_path_test.go # Functional test cases
+```
+
+## Available Assertions
+
+| Method                                            | Description                           |
+|---------------------------------------------------|---------------------------------------|
+| `ExpectTaskPassed()`                              | Assert the task passed                |
+| `ExpectTaskFailed()`                              | Assert the task failed                |
+| `ExpectTaskFailedWithError(contains)`             | Assert failure with specific error    |
+| `ExpectExitCode(code)`                            | Assert command exit code              |
+| `ExpectToolCalled(server, tool)`                  | Assert a tool was called              |
+| `ExpectToolCalledTimes(server, tool, n)`          | Assert tool called exactly n times    |
+| `ExpectToolCalledWithArgs(server, tool, matcher)` | Assert tool called with specific args |
+| `ExpectToolNotCalled(server, tool)`               | Assert a tool was not called          |
+| `ExpectJudgeCalled()`                             | Assert the LLM judge was invoked      |
+| `ExpectJudgeNotCalled()`                          | Assert the LLM judge was not invoked  |
+| `ExpectOutputContains(substring)`                 | Assert command output contains text   |
+| `ExpectOutputMatches(pattern)`                    | Assert command output matches regex   |
+
+## Environment Variables
+
+| Variable                | Description                             |
+|-------------------------|-----------------------------------------|
+| `MCPCHECKER_BINARY`         | Path to mcpchecker binary (subprocess mode) |
+| `MOCK_AGENT_BINARY`         | Path to mock agent binary                   |
+| `MCPCHECKER_TEST_INPROCESS` | Set to `true` to enable in-process mode     |
+
+## Thread Safety Note
+
+In-process mode modifies global state (`os.Args`, `os.Stdout`, working directory). A mutex ensures only one in-process test runs at a time. The `-p=1` flag in `make functional-coverage` enforces sequential test execution for safety.

--- a/functional/testcase/case.go
+++ b/functional/testcase/case.go
@@ -3,6 +3,7 @@
 package testcase
 
 import (
+	"os"
 	"testing"
 )
 
@@ -22,6 +23,9 @@ type TestCase struct {
 
 	// Assertions to run after the test
 	assertions []Assertion
+
+	// Execution mode
+	inProcess bool // If true, run mcpchecker in-process instead of subprocess
 }
 
 // New creates a new test case with the given name
@@ -196,4 +200,22 @@ func (tc *TestCase) Run() {
 // Name returns the test case name
 func (tc *TestCase) Name() string {
 	return tc.name
+}
+
+// WithInProcess enables in-process execution mode for this test case.
+// In this mode, the mcpchecker CLI is executed in-process instead of spawning
+// a subprocess, enabling code coverage collection and IDE debugging.
+func (tc *TestCase) WithInProcess() *TestCase {
+	tc.inProcess = true
+	return tc
+}
+
+// IsInProcess returns true if the test should run in in-process mode.
+// This is true if either WithInProcess() was called on the test case,
+// or if the MCPCHECKER_TEST_INPROCESS environment variable is set to "true".
+func (tc *TestCase) IsInProcess() bool {
+	if tc.inProcess {
+		return true
+	}
+	return os.Getenv(EnvInProcessMode) == "true"
 }

--- a/functional/testcase/inprocess.go
+++ b/functional/testcase/inprocess.go
@@ -1,0 +1,192 @@
+package testcase
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/mcpchecker/mcpchecker/pkg/cli"
+)
+
+// EnvInProcessMode is the environment variable to enable in-process execution mode.
+// When set to "true", functional tests will execute the mcpchecker CLI in-process
+// instead of spawning a subprocess. This enables code coverage collection and
+// IDE debugging with breakpoints.
+const EnvInProcessMode = "MCPCHECKER_TEST_INPROCESS"
+
+// inProcessMutex ensures only one in-process test runs at a time.
+// This is necessary because in-process mode modifies global state
+// (os.Args, os.Stdout, os.Stderr, working directory, environment variables).
+var inProcessMutex sync.Mutex
+
+// InProcessResult holds the result of an in-process CLI execution.
+type InProcessResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+	Err      error
+}
+
+// InProcessExecutor executes the mcpchecker CLI in-process.
+// It captures stdout/stderr, manages working directory, and handles
+// environment variables while preserving and restoring the original state.
+type InProcessExecutor struct {
+	Args    []string          // Command line arguments (excluding program name)
+	Dir     string            // Working directory for execution
+	Env     map[string]string // Environment variables to set
+	BaseEnv []string          // Base environment (os.Environ() if nil)
+}
+
+// Execute runs the mcpchecker CLI in-process and returns the result.
+// Thread-safe: uses a mutex to ensure only one in-process execution at a time.
+func (e *InProcessExecutor) Execute() *InProcessResult {
+	inProcessMutex.Lock()
+	defer inProcessMutex.Unlock()
+
+	result := &InProcessResult{}
+
+	// Save original state
+	origArgs := os.Args
+	origDir, origDirErr := os.Getwd()
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	origEnv := captureEnv()
+
+	if origDirErr != nil {
+		result.Err = origDirErr
+		result.ExitCode = 1
+		return result
+	}
+
+	// Restore original state when done
+	defer func() {
+		os.Args = origArgs
+		_ = os.Chdir(origDir)
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+		restoreEnv(origEnv)
+	}()
+
+	// Set up os.Args for Cobra
+	os.Args = append([]string{"mcpchecker"}, e.Args...)
+
+	// Change working directory if specified
+	if e.Dir != "" {
+		if err := os.Chdir(e.Dir); err != nil {
+			result.Err = err
+			result.ExitCode = 1
+			return result
+		}
+	}
+
+	// Set environment variables
+	baseEnv := e.BaseEnv
+	if baseEnv == nil {
+		baseEnv = os.Environ()
+	}
+	setEnv(baseEnv, e.Env)
+
+	// Capture stdout
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		result.Err = err
+		result.ExitCode = 1
+		return result
+	}
+
+	// Capture stderr
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		_ = stdoutR.Close()
+		_ = stdoutW.Close()
+		result.Err = err
+		result.ExitCode = 1
+		return result
+	}
+
+	os.Stdout = stdoutW
+	os.Stderr = stderrW
+
+	// Channel to collect captured output
+	stdoutCh := make(chan string)
+	stderrCh := make(chan string)
+
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, stdoutR)
+		stdoutCh <- buf.String()
+	}()
+
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, stderrR)
+		stderrCh <- buf.String()
+	}()
+
+	// Execute the CLI
+	result.Err = cli.Execute()
+
+	// Close write ends to signal EOF to readers
+	_ = stdoutW.Close()
+	_ = stderrW.Close()
+
+	// Collect captured output
+	result.Stdout = <-stdoutCh
+	result.Stderr = <-stderrCh
+
+	// Close read ends
+	_ = stdoutR.Close()
+	_ = stderrR.Close()
+
+	// Determine exit code
+	if result.Err != nil {
+		result.ExitCode = 1
+	} else {
+		result.ExitCode = 0
+	}
+
+	return result
+}
+
+// captureEnv returns a map of all current environment variables.
+func captureEnv() map[string]string {
+	env := make(map[string]string)
+	for _, e := range os.Environ() {
+		for i := 0; i < len(e); i++ {
+			if e[i] == '=' {
+				env[e[:i]] = e[i+1:]
+				break
+			}
+		}
+	}
+	return env
+}
+
+// setEnv clears the environment and sets variables from base and additional.
+func setEnv(base []string, additional map[string]string) {
+	os.Clearenv()
+
+	// Set base environment
+	for _, e := range base {
+		for i := 0; i < len(e); i++ {
+			if e[i] == '=' {
+				_ = os.Setenv(e[:i], e[i+1:])
+				break
+			}
+		}
+	}
+
+	// Set additional environment variables
+	for k, v := range additional {
+		_ = os.Setenv(k, v)
+	}
+}
+
+// restoreEnv restores the environment to the given state.
+func restoreEnv(env map[string]string) {
+	os.Clearenv()
+	for k, v := range env {
+		_ = os.Setenv(k, v)
+	}
+}


### PR DESCRIPTION
Add opt-in in-process execution mode for functional tests, enabling:
- Code coverage collection via `make functional-coverage`
- IDE debugging with breakpoints in production code

Controlled by environment variable MCPCHECKER_TEST_INPROCESS=true or per-test via .WithInProcess() fluent method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-process execution mode for functional tests, enabling per-test in-process debugging and coverage, with safeguards to ensure single-run thread safety.
  * New test target to run functional tests with coverage and generate an HTML coverage report.

* **Documentation**
  * Added a comprehensive functional test guide covering running modes (subprocess/in-process), examples, assertions, environment variables, debugging, coverage, and notes on sequential/in-process execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->