### PR TITLE
cleanup: rename gevals references to mcpchecker

### DIFF
--- a/.claude/skills/create-eval/SKILL.md
+++ b/.claude/skills/create-eval/SKILL.md
@@ -27,10 +27,10 @@ extending an existing eval. In this case, you will only need to modify some of t
 To run the evals, use:
 
 ```bash
-gevals run <path to eval yaml file>
+mcpchecker run <path to eval yaml file>
 ```
 
-The `gevals` binary may or may not be in the `$PATH`. If it is not in the path, ask the user where it is.
+The `mcpchecker` binary may or may not be in the `$PATH`. If it is not in the path, ask the user where it is.
 
 ## Examples
 

--- a/.github/actions/mcpchecker-action/action.yaml
+++ b/.github/actions/mcpchecker-action/action.yaml
@@ -1,14 +1,14 @@
-name: 'Run gevals MCP Evaluation'
-description: 'Evaluate MCP servers using the gevals framework'
-author: 'genmcp'
+name: 'Run mcpchecker MCP Evaluation'
+description: 'Evaluate MCP servers using the mcpchecker framework'
+author: 'mcpchecker'
 
 inputs:
   eval-config:
     description: 'Path to eval.yaml configuration file'
     required: true
 
-  gevals-version:
-    description: 'Version of gevals to use (latest, main, or vX.Y.Z)'
+  mcpchecker-version:
+    description: 'Version of mcpchecker to use (latest, main, or vX.Y.Z)'
     required: false
     default: 'latest'
 
@@ -35,7 +35,7 @@ inputs:
   artifact-name:
     description: 'Name for uploaded artifacts'
     required: false
-    default: 'gevals-results'
+    default: 'mcpchecker-results'
 
   fail-on-error:
     description: 'Fail the workflow if evaluation fails'
@@ -90,9 +90,9 @@ outputs:
     description: 'Total number of tasks with assertions evaluated'
     value: ${{ steps.run-eval.outputs.assertions-total }}
 
-  gevals-path:
-    description: 'Path to the installed gevals binary'
-    value: ${{ steps.install.outputs.gevals-path }}
+  mcpchecker-path:
+    description: 'Path to the installed mcpchecker binary'
+    value: ${{ steps.install.outputs.mcpchecker-path }}
 
   agent-path:
     description: 'Path to the installed agent binary'
@@ -164,7 +164,7 @@ runs:
         go-version: '1.25.x'
         cache: false
 
-    - name: Install gevals
+    - name: Install mcpchecker
       id: install
       shell: bash
       env:
@@ -173,56 +173,56 @@ runs:
         BIN_EXT: ${{ steps.platform.outputs.bin-ext }}
         BINARY_SUFFIX: ${{ steps.platform.outputs.binary-suffix }}
       run: |
-        INSTALL_DIR="${{ runner.temp }}/gevals-bin"
+        INSTALL_DIR="${{ runner.temp }}/mcpchecker-bin"
         mkdir -p "$INSTALL_DIR"
 
-        GEVALS_BIN="$INSTALL_DIR/gevals$BIN_EXT"
+        MCPCHECKER_BIN="$INSTALL_DIR/mcpchecker$BIN_EXT"
         AGENT_BIN="$INSTALL_DIR/agent$BIN_EXT"
 
         # Determine effective version to use
-        REQUESTED_VERSION="${{ inputs.gevals-version }}"
+        REQUESTED_VERSION="${{ inputs.mcpchecker-version }}"
         ACTION_REF="${{ github.action_ref }}"
 
         # If version is 'latest' and the action was called with a version tag ref,
         # use the action ref as the version (enables automatic version matching)
         if [ "$REQUESTED_VERSION" = "latest" ] && [[ "$ACTION_REF" =~ ^v[0-9] ]]; then
-          echo "Detected action ref '$ACTION_REF' - using as gevals version"
+          echo "Detected action ref '$ACTION_REF' - using as mcpchecker version"
           EFFECTIVE_VERSION="$ACTION_REF"
         else
           EFFECTIVE_VERSION="$REQUESTED_VERSION"
         fi
 
-        echo "Effective gevals version: $EFFECTIVE_VERSION"
+        echo "Effective mcpchecker version: $EFFECTIVE_VERSION"
 
         if [ "$EFFECTIVE_VERSION" = "latest" ] || [ "$EFFECTIVE_VERSION" = "main" ]; then
-          echo "Building gevals from source for $GOOS/$GOARCH..."
+          echo "Building mcpchecker from source for $GOOS/$GOARCH..."
 
-          # Clone gevals repository
-          GEVALS_SRC="${{ runner.temp }}/gevals-src"
-          git clone --depth 1 https://github.com/genmcp/gevals.git "$GEVALS_SRC"
-          cd "$GEVALS_SRC"
+          # Clone mcpchecker repository
+          MCPCHECKER_SRC="${{ runner.temp }}/mcpchecker-src"
+          git clone --depth 1 https://github.com/mcpchecker/mcpchecker.git "$MCPCHECKER_SRC"
+          cd "$MCPCHECKER_SRC"
 
           # Build binaries
           make build GOOS=$GOOS GOARCH=$GOARCH
 
           # Copy built binaries to install directory
-          mv gevals$BIN_EXT "$GEVALS_BIN"
+          mv mcpchecker$BIN_EXT "$MCPCHECKER_BIN"
           mv agent$BIN_EXT "$AGENT_BIN"
 
           # Cleanup source
           cd -
-          rm -rf "$GEVALS_SRC"
+          rm -rf "$MCPCHECKER_SRC"
         else
-          echo "Downloading pre-built gevals $EFFECTIVE_VERSION for $BINARY_SUFFIX..."
+          echo "Downloading pre-built mcpchecker $EFFECTIVE_VERSION for $BINARY_SUFFIX..."
 
           # Download from GitHub releases
-          RELEASE_URL="https://github.com/genmcp/gevals/releases/download/$EFFECTIVE_VERSION"
-          DOWNLOAD_DIR="${{ runner.temp }}/gevals-download"
+          RELEASE_URL="https://github.com/mcpchecker/mcpchecker/releases/download/$EFFECTIVE_VERSION"
+          DOWNLOAD_DIR="${{ runner.temp }}/mcpchecker-download"
           mkdir -p "$DOWNLOAD_DIR"
 
-          # Download pre-built gevals zip
-          if ! curl -fsSL "$RELEASE_URL/gevals-$BINARY_SUFFIX.zip" -o "$DOWNLOAD_DIR/gevals.zip" 2>&1; then
-            echo "❌ Failed to download pre-built gevals release for $BINARY_SUFFIX"
+          # Download pre-built mcpchecker zip
+          if ! curl -fsSL "$RELEASE_URL/mcpchecker-$BINARY_SUFFIX.zip" -o "$DOWNLOAD_DIR/mcpchecker.zip" 2>&1; then
+            echo "❌ Failed to download pre-built mcpchecker release for $BINARY_SUFFIX"
             echo "   Check that version '$EFFECTIVE_VERSION' exists and has release artifacts"
             exit 1
           fi
@@ -234,24 +234,24 @@ runs:
           fi
 
           # Extract zips
-          echo "Extracting gevals..."
-          unzip -q "$DOWNLOAD_DIR/gevals.zip" -d "$DOWNLOAD_DIR"
-          mv "$DOWNLOAD_DIR/gevals-$BINARY_SUFFIX$BIN_EXT" "$GEVALS_BIN"
+          echo "Extracting mcpchecker..."
+          unzip -q "$DOWNLOAD_DIR/mcpchecker.zip" -d "$DOWNLOAD_DIR"
+          mv "$DOWNLOAD_DIR/mcpchecker-$BINARY_SUFFIX$BIN_EXT" "$MCPCHECKER_BIN"
 
           echo "Extracting agent..."
           unzip -q "$DOWNLOAD_DIR/agent.zip" -d "$DOWNLOAD_DIR"
           mv "$DOWNLOAD_DIR/agent-$BINARY_SUFFIX$BIN_EXT" "$AGENT_BIN"
 
           # Make binaries executable (not needed on Windows, but harmless)
-          chmod +x "$GEVALS_BIN" "$AGENT_BIN"
+          chmod +x "$MCPCHECKER_BIN" "$AGENT_BIN"
 
           # Cleanup download directory
           rm -rf "$DOWNLOAD_DIR"
         fi
 
         # Verify binaries exist
-        if [ ! -f "$GEVALS_BIN" ]; then
-          echo "❌ gevals binary not found at $GEVALS_BIN"
+        if [ ! -f "$MCPCHECKER_BIN" ]; then
+          echo "❌ mcpchecker binary not found at $MCPCHECKER_BIN"
           exit 1
         fi
 
@@ -261,22 +261,22 @@ runs:
         fi
 
         # Output paths and version
-        echo "gevals-path=$GEVALS_BIN" >> $GITHUB_OUTPUT
+        echo "mcpchecker-path=$MCPCHECKER_BIN" >> $GITHUB_OUTPUT
         echo "agent-path=$AGENT_BIN" >> $GITHUB_OUTPUT
         echo "effective-version=$EFFECTIVE_VERSION" >> $GITHUB_OUTPUT
 
         # Add to PATH for subsequent steps
         echo "$INSTALL_DIR" >> $GITHUB_PATH
 
-        echo "✓ Installed gevals to $GEVALS_BIN"
+        echo "✓ Installed mcpchecker to $MCPCHECKER_BIN"
         echo "✓ Installed agent to $AGENT_BIN"
 
-    - name: Verify gevals installation
+    - name: Verify mcpchecker installation
       shell: bash
       run: |
-        echo "Verifying gevals installation..."
-        ${{ steps.install.outputs.gevals-path }} help
-        echo "✓ gevals installed successfully"
+        echo "Verifying mcpchecker installation..."
+        ${{ steps.install.outputs.mcpchecker-path }} help
+        echo "✓ mcpchecker installed successfully"
         echo ""
         echo "Platform: ${{ steps.platform.outputs.goos }}/${{ steps.platform.outputs.goarch }}"
         echo "Version: ${{ steps.install.outputs.effective-version }}"
@@ -287,7 +287,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         # Build command as array (safe from shell injection)
-        CMD=("${{ steps.install.outputs.gevals-path }}" "eval" "${{ inputs.eval-config }}")
+        CMD=("${{ steps.install.outputs.mcpchecker-path }}" "eval" "${{ inputs.eval-config }}")
 
         # Add optional flags as separate array elements
         if [ -n "${{ inputs.output-format }}" ]; then
@@ -314,7 +314,7 @@ runs:
 
         # Find results file (deterministic: pick most recently modified)
         # ls -t sorts by modification time (newest first), ensuring deterministic selection
-        RESULTS_FILE=$(ls -t gevals-*-out.json 2>/dev/null | head -1 || echo "")
+        RESULTS_FILE=$(ls -t mcpchecker-*-out.json 2>/dev/null | head -1 || echo "")
 
         if [ -n "$RESULTS_FILE" ]; then
           echo "Results file: $RESULTS_FILE"
@@ -440,7 +440,7 @@ runs:
       with:
         name: ${{ inputs.artifact-name }}
         path: |
-          ${{ inputs.working-directory }}/gevals-*-out.json
+          ${{ inputs.working-directory }}/mcpchecker-*-out.json
           ${{ inputs.working-directory }}/*-error.txt
         if-no-files-found: warn
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,10 +19,10 @@ updates:
           - "*"
 
   - package-ecosystem: "github-actions"
-    directory: "/.github/actions/gevals-action"
+    directory: "/.github/actions/mcpchecker-action"
     schedule:
       interval: "weekly"
     groups:
-      gevals-action-dependencies:
+      mcpchecker-action-dependencies:
         patterns:
           - "*"

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ go.work.sum
 
 # built binary
 /agent
-/gevals
+/mcpchecker
 
 # release artifacts
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Renamed project from gevals to mcpchecker, migrated to mcpchecker github org
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 AGENT_BINARY_NAME = agent
-GEVALS_BINARY_NAME = gevals
+MCPCHECKER_BINARY_NAME = mcpchecker
 MOCK_AGENT_BINARY_NAME = functional/mock-agent
 
 # Release build variables (can be overridden)
@@ -14,19 +14,19 @@ endef
 
 .PHONY: clean
 clean:
-	rm -f $(AGENT_BINARY_NAME) $(GEVALS_BINARY_NAME) $(MOCK_AGENT_BINARY_NAME)
+	rm -f $(AGENT_BINARY_NAME) $(MCPCHECKER_BINARY_NAME) $(MOCK_AGENT_BINARY_NAME)
 	rm -f *.zip *.bundle
 
 .PHONY: build-agent
 build-agent: clean
 	go build -o $(AGENT_BINARY_NAME) ./cmd/agent
 
-.PHONY: build-gevals
-build-gevals: clean
-	go build -o $(GEVALS_BINARY_NAME) ./cmd/gevals/
+.PHONY: build-mcpchecker
+build-mcpchecker: clean
+	go build -o $(MCPCHECKER_BINARY_NAME) ./cmd/mcpchecker/
 
 .PHONY: build
-build: build-agent build-gevals
+build: build-agent build-mcpchecker
 
 .PHONY: test
 test:
@@ -39,7 +39,7 @@ _build-mock-agent:
 
 .PHONY: functional
 functional: build _build-mock-agent ## Run functional tests
-	GEVALS_BINARY=$(CURDIR)/gevals MOCK_AGENT_BINARY=$(CURDIR)/$(MOCK_AGENT_BINARY_NAME) go test -v -tags functional ./functional/...
+	MCPCHECKER_BINARY=$(CURDIR)/mcpchecker MOCK_AGENT_BINARY=$(CURDIR)/$(MOCK_AGENT_BINARY_NAME) go test -v -tags functional ./functional/...
 
 # Release targets for CI/CD
 .PHONY: build-release
@@ -47,10 +47,10 @@ build-release:
 	@echo "Building release binaries for $(GOOS)/$(GOARCH)..."
 	@mkdir -p dist
 	@if [ "$(GOOS)" = "windows" ]; then \
-		GOOS=$(GOOS) GOARCH=$(GOARCH) go build -trimpath -ldflags="-s -w" -o "dist/$(GEVALS_BINARY_NAME)-$(GOOS)-$(GOARCH).exe" ./cmd/gevals; \
+		GOOS=$(GOOS) GOARCH=$(GOARCH) go build -trimpath -ldflags="-s -w" -o "dist/$(MCPCHECKER_BINARY_NAME)-$(GOOS)-$(GOARCH).exe" ./cmd/mcpchecker; \
 		GOOS=$(GOOS) GOARCH=$(GOARCH) go build -trimpath -ldflags="-s -w" -o "dist/$(AGENT_BINARY_NAME)-$(GOOS)-$(GOARCH).exe" ./cmd/agent; \
 	else \
-		GOOS=$(GOOS) GOARCH=$(GOARCH) go build -trimpath -ldflags="-s -w" -o "dist/$(GEVALS_BINARY_NAME)-$(GOOS)-$(GOARCH)" ./cmd/gevals; \
+		GOOS=$(GOOS) GOARCH=$(GOARCH) go build -trimpath -ldflags="-s -w" -o "dist/$(MCPCHECKER_BINARY_NAME)-$(GOOS)-$(GOARCH)" ./cmd/mcpchecker; \
 		GOOS=$(GOOS) GOARCH=$(GOARCH) go build -trimpath -ldflags="-s -w" -o "dist/$(AGENT_BINARY_NAME)-$(GOOS)-$(GOARCH)" ./cmd/agent; \
 	fi
 	@echo "Build complete!"
@@ -60,10 +60,10 @@ package-release:
 	@echo "Packaging release artifacts for $(GOOS)/$(GOARCH)..."
 	@cd dist && \
 	if [ "$(GOOS)" = "windows" ]; then \
-		zip "$(GEVALS_BINARY_NAME)-$(GOOS)-$(GOARCH).zip" "$(GEVALS_BINARY_NAME)-$(GOOS)-$(GOARCH).exe"; \
+		zip "$(MCPCHECKER_BINARY_NAME)-$(GOOS)-$(GOARCH).zip" "$(MCPCHECKER_BINARY_NAME)-$(GOOS)-$(GOARCH).exe"; \
 		zip "$(AGENT_BINARY_NAME)-$(GOOS)-$(GOARCH).zip" "$(AGENT_BINARY_NAME)-$(GOOS)-$(GOARCH).exe"; \
 	else \
-		zip "$(GEVALS_BINARY_NAME)-$(GOOS)-$(GOARCH).zip" "$(GEVALS_BINARY_NAME)-$(GOOS)-$(GOARCH)"; \
+		zip "$(MCPCHECKER_BINARY_NAME)-$(GOOS)-$(GOARCH).zip" "$(MCPCHECKER_BINARY_NAME)-$(GOOS)-$(GOARCH)"; \
 		zip "$(AGENT_BINARY_NAME)-$(GOOS)-$(GOARCH).zip" "$(AGENT_BINARY_NAME)-$(GOOS)-$(GOARCH)"; \
 	fi
 	@echo "Packaging complete!"
@@ -72,8 +72,8 @@ package-release:
 sign-release:
 	@echo "Signing release artifacts for $(GOOS)/$(GOARCH)..."
 	@cd dist && \
-	cosign sign-blob --yes "$(GEVALS_BINARY_NAME)-$(GOOS)-$(GOARCH).zip" \
-		--bundle "$(GEVALS_BINARY_NAME)-$(GOOS)-$(GOARCH).zip.bundle" && \
+	cosign sign-blob --yes "$(MCPCHECKER_BINARY_NAME)-$(GOOS)-$(GOARCH).zip" \
+		--bundle "$(MCPCHECKER_BINARY_NAME)-$(GOOS)-$(GOARCH).zip.bundle" && \
 	cosign sign-blob --yes "$(AGENT_BINARY_NAME)-$(GOOS)-$(GOARCH).zip" \
 		--bundle "$(AGENT_BINARY_NAME)-$(GOOS)-$(GOARCH).zip.bundle"
 	@echo "Signing complete!"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# gevals
+# mcpchecker
 
 🧪 Test your MCP servers by having AI agents complete real tasks.
 
 ## What It Does
 
-gevals validates MCP servers by:
+mcpchecker validates MCP servers by:
 1. 🔧 Running setup scripts (e.g., create test namespace)
 2. 🤖 Giving an AI agent a task prompt (e.g., "create a nginx pod")
 3. 📝 Recording which MCP tools the agent uses
@@ -18,15 +18,15 @@ If agents successfully complete tasks using your MCP server, your tools are well
 
 ```bash
 # Build
-go build -o gevals ./cmd/gevals
+go build -o mcpchecker ./cmd/mcpchecker
 
 # Run the example (requires Kubernetes cluster + MCP server)
-./gevals eval examples/kubernetes/eval.yaml
+./mcpchecker eval examples/kubernetes/eval.yaml
 ```
 
 The tool will:
 - Display progress in real-time
-- Save results to `gevals-<name>-out.json`
+- Save results to `mcpchecker-<name>-out.json`
 - Show pass/fail summary
 
 ## Example Setup
@@ -291,7 +291,7 @@ Pass/fail means:
 
 ## Output
 
-Results saved to `gevals-<eval-name>-out.json`:
+Results saved to `mcpchecker-<eval-name>-out.json`:
 
 ```json
 {
@@ -341,7 +341,7 @@ Use inline configuration for simple setups with built-in agents. Use a separate 
 
 ### Built-in Agent Types
 
-gevals provides built-in configurations for popular AI agents to eliminate boilerplate:
+mcpchecker provides built-in configurations for popular AI agents to eliminate boilerplate:
 
 **Claude Code**:
 ```yaml

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Release Guide
 
-This document describes how to create releases for the gevals project.
+This document describes how to create releases for the mcpchecker project.
 
 ## Release Types
 
@@ -66,7 +66,7 @@ Stable releases follow semantic versioning (vX.Y.Z) and are triggered by pushing
 
 5. **Verify the release**
 
-   Check the [releases page](https://github.com/genmcp/gevals/releases) to ensure:
+   Check the [releases page](https://github.com/mcpchecker/mcpchecker/releases) to ensure:
    - The release was created successfully
    - All artifacts are present (12 zip files + 12 bundles)
    - The changelog was extracted correctly
@@ -129,7 +129,7 @@ The nightly workflow:
 
 To trigger a nightly build manually:
 
-1. Go to the [Actions tab](https://github.com/genmcp/gevals/actions/workflows/nightly.yaml)
+1. Go to the [Actions tab](https://github.com/mcpchecker/mcpchecker/actions/workflows/nightly.yaml)
 2. Click "Run workflow"
 3. Select the branch (usually `main`)
 4. Click "Run workflow"
@@ -162,15 +162,15 @@ Users can verify artifact signatures using the bundle format:
 
 ```bash
 # Download artifacts
-wget https://github.com/genmcp/gevals/releases/download/v1.0.0/gevals-linux-amd64.zip
-wget https://github.com/genmcp/gevals/releases/download/v1.0.0/gevals-linux-amd64.zip.bundle
+wget https://github.com/mcpchecker/mcpchecker/releases/download/v1.0.0/mcpchecker-linux-amd64.zip
+wget https://github.com/mcpchecker/mcpchecker/releases/download/v1.0.0/mcpchecker-linux-amd64.zip.bundle
 
 # Verify using bundle (simplified format)
 cosign verify-blob \
-  --bundle gevals-linux-amd64.zip.bundle \
-  --certificate-identity-regexp 'https://github.com/genmcp/gevals' \
+  --bundle mcpchecker-linux-amd64.zip.bundle \
+  --certificate-identity-regexp 'https://github.com/mcpchecker/mcpchecker' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  gevals-linux-amd64.zip
+  mcpchecker-linux-amd64.zip
 ```
 
 The bundle file contains both the signature and certificate, making verification simpler compared to the older separate `.sig` and `.pem` files.

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/genmcp/gevals/pkg/openaiagent"
+	"github.com/mcpchecker/mcpchecker/pkg/openaiagent"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/mcpchecker/main.go
+++ b/cmd/mcpchecker/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/genmcp/gevals/pkg/cli"
+	"github.com/mcpchecker/mcpchecker/pkg/cli"
 )
 
 func main() {

--- a/docs/dev/DEV_DEBUGGING_NOTES.md
+++ b/docs/dev/DEV_DEBUGGING_NOTES.md
@@ -1,14 +1,14 @@
-# Gevals Debugging Notes
+# Mcpchecker Debugging Notes
 
 This project supports an opt-in debugging mode that preserves the temporary
 files created while the agent runs. Enable it per invocation:
 
 ```bash
-GEVALS_DEBUG=1 ./gevals run <path-to-eval>
+MCPCHECKER_DEBUG=1 ./mcpchecker run <path-to-eval>
 ```
 
-When `GEVALS_DEBUG` is set, the agent runner creates a directory such as
-`/tmp/gevals-debug-XXXXXXXX`. If the agent command fails, the error message will
+When `MCPCHECKER_DEBUG` is set, the agent runner creates a directory such as
+`/tmp/mcpchecker-debug-XXXXXXXX`. If the agent command fails, the error message will
 include the exact path. Inside you will find:
 
 - `config.toml` – the Codex configuration file generated for the attempt.

--- a/docs/specs/extension-protocol.md
+++ b/docs/specs/extension-protocol.md
@@ -1,11 +1,11 @@
-# gevals Extension Protocol Specification
+# mcpchecker Extension Protocol Specification
 
 **Version**: 0.0.1
 **Status**: Draft
 
 ## Overview
 
-This document specifies the communication protocol between gevals and extension binaries. Extensions provide domain-specific operations (e.g., Kubernetes resource management, database queries) that can be used in task setup, verification, and cleanup phases.
+This document specifies the communication protocol between mcpchecker and extension binaries. Extensions provide domain-specific operations (e.g., Kubernetes resource management, database queries) that can be used in task setup, verification, and cleanup phases.
 
 The protocol is based on JSON-RPC 2.0 over newline-delimited stdio.
 
@@ -15,41 +15,41 @@ The protocol is based on JSON-RPC 2.0 over newline-delimited stdio.
 |----------|-------|
 | Framing | Newline-delimited JSON (each message is one line terminated by `\n`) |
 | Encoding | UTF-8 |
-| Input | gevals writes to extension's stdin |
+| Input | mcpchecker writes to extension's stdin |
 | Output | Extension writes to stdout |
-| Stderr | Reserved for debug logs (not parsed by gevals) |
+| Stderr | Reserved for debug logs (not parsed by mcpchecker) |
 
 ## Lifecycle
 
 ```
-┌────────┐                              ┌─────────────┐
-│ gevals │                              │  extension  │
-└───┬────┘                              └──────┬──────┘
-    │                                          │
-    │──── spawn process ──────────────────────▶│
-    │                                          │
-    │──── initialize ─────────────────────────▶│
-    │◀─── manifest ───────────────────────────│
-    │                                          │
-    │──── execute ────────────────────────────▶│
-    │◀─── log (0..n) ─────────────────────────│
-    │◀─── result ─────────────────────────────│
-    │                                          │
-    │     ... more execute requests ...        │
-    │                                          │
-    │──── shutdown ───────────────────────────▶│
-    │◀─── ack ────────────────────────────────│
-    │                                          │
-    │◀─── process exits ──────────────────────│
+┌────────────┐                              ┌─────────────┐
+│ mcpchecker │                              │  extension  │
+└───┬────────┘                              └──────┬──────┘
+    │                                              │
+    │──── spawn process ──────────────────────────▶│
+    │                                              │
+    │──── initialize ─────────────────────────────▶│
+    │◀─── manifest ────────────────────────────────│
+    │                                              │
+    │──── execute ────────────────────────────────▶│
+    │◀─── log (0..n) ──────────────────────────────│
+    │◀─── result ──────────────────────────────────│
+    │                                              │
+    │     ... more execute requests ...            │
+    │                                              │
+    │──── shutdown ───────────────────────────────▶│
+    │◀─── ack ─────────────────────────────────────│
+    │                                              │
+    │◀─── process exits ───────────────────────────│
 ```
 
-1. gevals spawns the extension binary
-2. gevals sends `initialize` request
+1. mcpchecker spawns the extension binary
+2. mcpchecker sends `initialize` request
 3. Extension responds with its manifest (name, version, available operations)
-4. gevals sends `execute` requests for operations
+4. mcpchecker sends `execute` requests for operations
 5. Extension may send `log` notifications during execution
 6. Extension sends result for each execute request
-7. gevals sends `shutdown` when done
+7. mcpchecker sends `shutdown` when done
 8. Extension exits
 
 ## Messages
@@ -76,7 +76,7 @@ Sent once after spawn. Returns extension manifest.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `protocolVersion` | string | Yes | Protocol version gevals supports |
+| `protocolVersion` | string | Yes | Protocol version mcpchecker supports |
 | `config` | object | No | Extension-specific configuration from eval spec |
 
 #### Response
@@ -316,7 +316,7 @@ Progress updates during execution. This is a JSON-RPC notification (no `id`, no 
 | `message` | string | Yes | Log message |
 | `data` | object | No | Structured data for debugging |
 
-gevals displays logs based on verbosity settings.
+mcpchecker displays logs based on verbosity settings.
 
 ---
 

--- a/docs/task-format.md
+++ b/docs/task-format.md
@@ -1,6 +1,6 @@
 # Task Format
 
-This document describes the task format used by gevals to define evaluation tasks.
+This document describes the task format used by mcpchecker to define evaluation tasks.
 
 ## Overview
 
@@ -11,10 +11,10 @@ Tasks define what an agent should do and how to verify it succeeded. Each task s
 - Verification steps to check the agent's work
 - Optional cleanup steps to run after verification
 
-gevals supports two API versions:
+mcpchecker supports two API versions:
 
-- `gevals/v1alpha2` - Declarative step-based format (recommended for new tasks)
-- `gevals/v1alpha1` - Legacy script-based format (still supported)
+- `mcpchecker/v1alpha2` - Declarative step-based format (recommended for new tasks)
+- `mcpchecker/v1alpha1` - Legacy script-based format (still supported)
 
 ## Task Schema
 
@@ -22,7 +22,7 @@ A v1alpha2 task has the following structure:
 
 ```yaml
 kind: Task
-apiVersion: gevals/v1alpha2
+apiVersion: mcpchecker/v1alpha2
 metadata:
   name: string        # Required. Unique task identifier.
   difficulty: string  # Optional. One of: easy, medium, hard.
@@ -62,7 +62,7 @@ Each step is a single-key map where the key is the step type and the value is th
 
 ## Built-in Step Types
 
-gevals provides three built-in step types.
+mcpchecker provides three built-in step types.
 
 ### http
 
@@ -195,7 +195,7 @@ metadata:
 config:
   extensions:
     kubernetes:                          # Extension alias (matches spec.requires)
-      package: https://github.com/genmcp/gevals-kubernetes-extension@v0.0.1
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.1
       config:                            # Optional. Extension-specific configuration.
         kubeconfig: ~/.kube/config
       env:                               # Optional. Environment variables for the extension.
@@ -245,7 +245,7 @@ Here is a complete v1alpha2 task that creates and verifies a Kubernetes pod:
 
 ```yaml
 kind: Task
-apiVersion: gevals/v1alpha2
+apiVersion: mcpchecker/v1alpha2
 metadata:
   name: create-nginx-pod
   difficulty: easy
@@ -314,7 +314,7 @@ steps:
     inline: "Do something"
 ```
 
-This format is still supported. Tasks without an `apiVersion` field or with `apiVersion: gevals/v1alpha1` use this format.
+This format is still supported. Tasks without an `apiVersion` field or with `apiVersion: mcpchecker/v1alpha1` use this format.
 
 The v1alpha1 format also supports LLM judge verification:
 
@@ -352,7 +352,7 @@ steps:
 
 ```yaml
 kind: Task
-apiVersion: gevals/v1alpha2
+apiVersion: mcpchecker/v1alpha2
 metadata:
   name: my-task
   difficulty: medium
@@ -375,7 +375,7 @@ spec:
 
 Key changes:
 
-1. Add `apiVersion: gevals/v1alpha2`
+1. Add `apiVersion: mcpchecker/v1alpha2`
 2. Move task definition under `spec`
 3. Replace `steps.setup.file: setup.sh` with a `script` step in `spec.setup`
 4. Each phase (`setup`, `verify`, `cleanup`) is now an array of steps
@@ -395,4 +395,4 @@ Once migrated, you can incrementally replace script steps with built-in steps or
 
 ## Extension Protocol
 
-Extensions communicate with gevals using JSON-RPC 2.0 over stdio. For details on implementing an extension, see [Extension Protocol Specification](specs/extension-protocol.md).
+Extensions communicate with mcpchecker using JSON-RPC 2.0 over stdio. For details on implementing an extension, see [Extension Protocol Specification](specs/extension-protocol.md).

--- a/examples/kube-mcp-server/README.md
+++ b/examples/kube-mcp-server/README.md
@@ -38,14 +38,14 @@ The tasks and MCP configuration are shared - only the agent configuration differ
 - Kubernetes cluster (kind, minikube, or any cluster)
 - kubectl configured
 - Kubernetes MCP server running at `http://localhost:8080/mcp`
-- Built binaries: `gevals` and `agent`
+- Built binaries: `mcpchecker` and `agent`
 
 ## Running Examples
 
 ### Option 1: Claude Code
 
 ```bash
-./gevals eval examples/kube-mcp-server/claude-code/eval.yaml
+./mcpchecker eval examples/kube-mcp-server/claude-code/eval.yaml
 ```
 
 **Requirements:**
@@ -65,7 +65,7 @@ export MODEL_KEY='your-api-key'
 export MODEL_NAME='your-model-name'
 
 # Run the test
-./gevals eval examples/kube-mcp-server/openai-agent/eval.yaml
+./mcpchecker eval examples/kube-mcp-server/openai-agent/eval.yaml
 ```
 
 **Note:** Different AI models may choose different tools from the MCP server (`pods_*` or `resources_*`) to accomplish the same task. Both approaches work correctly.
@@ -107,4 +107,4 @@ Both examples should produce:
 - ✅ Assertions passed - appropriate tools were called
 - ✅ Verification passed - pod exists and is running
 
-Results saved to: `gevals-<eval-name>-out.json`
+Results saved to: `mcpchecker-<eval-name>-out.json`

--- a/examples/kube-mcp-server/kubernetes-extension/cmd/main.go
+++ b/examples/kube-mcp-server/kubernetes-extension/cmd/main.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/genmcp/gevals/examples/kube-mcp-server/kubernetes-extension/pkg/extension"
+	"github.com/mcpchecker/mcpchecker/examples/kube-mcp-server/kubernetes-extension/pkg/extension"
 )
 
 func main() {

--- a/examples/kube-mcp-server/kubernetes-extension/go.mod
+++ b/examples/kube-mcp-server/kubernetes-extension/go.mod
@@ -1,11 +1,11 @@
-module github.com/genmcp/gevals/examples/kube-mcp-server/kubernetes-extension
+module github.com/mcpchecker/mcpchecker/examples/kube-mcp-server/kubernetes-extension
 
 go 1.25.5
 
-replace github.com/genmcp/gevals => ../../../
+replace github.com/mcpchecker/mcpchecker => ../../../
 
 require (
-	github.com/genmcp/gevals v0.0.0-00010101000000-000000000000
+	github.com/mcpchecker/mcpchecker v0.0.0-00010101000000-000000000000
 	github.com/google/jsonschema-go v0.4.2
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0

--- a/examples/kube-mcp-server/kubernetes-extension/pkg/extension/extension.go
+++ b/examples/kube-mcp-server/kubernetes-extension/pkg/extension/extension.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/genmcp/gevals/pkg/extension/sdk"
+	"github.com/mcpchecker/mcpchecker/pkg/extension/sdk"
 	"github.com/google/jsonschema-go/jsonschema"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/examples/kube-mcp-server/tasks/create-pod/create-pod.yaml
+++ b/examples/kube-mcp-server/tasks/create-pod/create-pod.yaml
@@ -1,5 +1,5 @@
 kind: Task
-apiVersion: gevals/v1alpha2
+apiVersion: mcpchecker/v1alpha2
 metadata:
   name: "create-nginx-pod"
   difficulty: easy

--- a/examples/net-edge/README.md
+++ b/examples/net-edge/README.md
@@ -1,6 +1,6 @@
 # NetEdge Scenario 1 (Service Selector Mismatch)
 
-Evaluate the NetEdge gen-mcp server **Route → Service selector mismatch** scenario with the `gevals`
+Evaluate the NetEdge gen-mcp server **Route → Service selector mismatch** scenario with the `mcpchecker`
 framework and the Codex GPT-5 coding agent.
 
 ## Layout
@@ -8,7 +8,7 @@ framework and the Codex GPT-5 coding agent.
 ```text
 net-edge/
 ├── README.md                         # This file
-├── mcp-config.yaml                   # Launches the gen-mcp NetEdge server for gevals
+├── mcp-config.yaml                   # Launches the gen-mcp NetEdge server for mcpchecker
 ├── codex-agent/
 │   ├── agent.yaml                    # Codex CLI wiring
 │   └── eval.yaml                     # Eval definition (scenario 1)
@@ -49,7 +49,7 @@ command = "/Users/you/workspace/gen-mcp/genmcp"
 args    = ["run", "-f", "/Users/you/workspace/gen-mcp/examples/netedge-tools/mcpfile.yaml"]
 ```
 
-The eval overrides the MCP server connection at runtime, pointing Codex at the HTTP proxy that `gevals`
+The eval overrides the MCP server connection at runtime, pointing Codex at the HTTP proxy that `mcpchecker`
 launches for the stdio NetEdge server. Modern Codex builds accept direct HTTP MCP connections (see
 the [Codex MCP guide](https://developers.openai.com/codex/mcp)), so no external shim is required,
 but Codex still needs a profile that can use the API key.
@@ -64,11 +64,11 @@ export OPENAI_API_KEY=sk-...
 
 1. Build the project (from repo root): `make build`
 2. Ensure your current shell can reach the OpenShift cluster (`oc whoami` should succeed).
-3. Ensure `OPENAI_API_KEY` is exported in the shell that will launch `gevals`.
+3. Ensure `OPENAI_API_KEY` is exported in the shell that will launch `mcpchecker`.
 4. Run the evaluation:
 
  ```bash
- ./gevals eval examples/net-edge/codex-agent/eval.yaml
+ ./mcpchecker eval examples/net-edge/codex-agent/eval.yaml
  ```
 
 ## Running with Gemini
@@ -79,11 +79,11 @@ export OPENAI_API_KEY=sk-...
 4. Run the evaluation:
 
  ```bash
- ./gevals eval examples/net-edge/gemini-agent/eval_1_selector-mismatch.yaml
+ ./mcpchecker eval examples/net-edge/gemini-agent/eval_1_selector-mismatch.yaml
  ```
 
 `setup.sh` deploys the hello workload, then intentionally breaks the Service selector so the Route loses its
 endpoints. The Codex agent must diagnose and repair the mismatch, after which `verify.sh` confirms the selector
-and endpoints are healthy. Results are written to `gevals-netedge-selector-mismatch-out.json` by default.
+and endpoints are healthy. Results are written to `mcpchecker-netedge-selector-mismatch-out.json` by default.
 
 For advanced debugging tips refer to `docs/dev/DEV_DEBUGGING_NOTES.md` in the repo root.

--- a/functional/servers/agent/cmd/main.go
+++ b/functional/servers/agent/cmd/main.go
@@ -10,7 +10,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/genmcp/gevals/functional/servers/agent"
+	"github.com/mcpchecker/mcpchecker/functional/servers/agent"
 )
 
 func main() {

--- a/functional/testcase/agent.go
+++ b/functional/testcase/agent.go
@@ -1,7 +1,7 @@
 package testcase
 
 import (
-	"github.com/genmcp/gevals/functional/servers/agent"
+	"github.com/mcpchecker/mcpchecker/functional/servers/agent"
 )
 
 // AgentBuilder provides a fluent API for configuring mock agent behavior.

--- a/functional/testcase/case.go
+++ b/functional/testcase/case.go
@@ -1,5 +1,5 @@
 // Package testcase provides a fluent API for defining functional test cases
-// that exercise the gevals binary against mock servers.
+// that exercise the mcpchecker binary against mock servers.
 package testcase
 
 import (

--- a/functional/testcase/eval_config.go
+++ b/functional/testcase/eval_config.go
@@ -1,8 +1,8 @@
 package testcase
 
 import (
-	"github.com/genmcp/gevals/pkg/eval"
-	"github.com/genmcp/gevals/pkg/llmjudge"
+	"github.com/mcpchecker/mcpchecker/pkg/eval"
+	"github.com/mcpchecker/mcpchecker/pkg/llmjudge"
 )
 
 // EvalConfig provides a fluent API for building eval configurations.

--- a/functional/testcase/expect.go
+++ b/functional/testcase/expect.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/genmcp/gevals/functional/servers/mcp"
-	"github.com/genmcp/gevals/functional/servers/openai"
-	"github.com/genmcp/gevals/pkg/eval"
+	"github.com/mcpchecker/mcpchecker/functional/servers/mcp"
+	"github.com/mcpchecker/mcpchecker/functional/servers/openai"
+	"github.com/mcpchecker/mcpchecker/pkg/eval"
 )
 
 // RunContext contains runtime data needed for assertions.

--- a/functional/testcase/generators.go
+++ b/functional/testcase/generators.go
@@ -8,10 +8,10 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"github.com/genmcp/gevals/functional/servers/agent"
-	"github.com/genmcp/gevals/pkg/eval"
-	"github.com/genmcp/gevals/pkg/task"
-	"github.com/genmcp/gevals/pkg/util"
+	"github.com/mcpchecker/mcpchecker/functional/servers/agent"
+	"github.com/mcpchecker/mcpchecker/pkg/eval"
+	"github.com/mcpchecker/mcpchecker/pkg/task"
+	"github.com/mcpchecker/mcpchecker/pkg/util"
 )
 
 // GeneratedFiles holds paths to all generated configuration files
@@ -32,7 +32,7 @@ type Generator struct {
 
 // NewGenerator creates a new generator with a temporary directory
 func NewGenerator(t *testing.T) (*Generator, error) {
-	tempDir, err := os.MkdirTemp("", "gevals-functional-*")
+	tempDir, err := os.MkdirTemp("", "mcpchecker-functional-*")
 	if err != nil {
 		return nil, err
 	}

--- a/functional/testcase/judge.go
+++ b/functional/testcase/judge.go
@@ -3,7 +3,7 @@ package testcase
 import (
 	"time"
 
-	"github.com/genmcp/gevals/functional/servers/openai"
+	"github.com/mcpchecker/mcpchecker/functional/servers/openai"
 )
 
 // JudgeBuilder provides a fluent API for configuring mock judge behavior.

--- a/functional/testcase/mcp.go
+++ b/functional/testcase/mcp.go
@@ -1,7 +1,7 @@
 package testcase
 
 import (
-	"github.com/genmcp/gevals/functional/servers/mcp"
+	"github.com/mcpchecker/mcpchecker/functional/servers/mcp"
 )
 
 // MCPServerBuilder builds a mock MCP server configuration

--- a/functional/testcase/task_config.go
+++ b/functional/testcase/task_config.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/genmcp/gevals/pkg/llmjudge"
-	"github.com/genmcp/gevals/pkg/steps"
-	"github.com/genmcp/gevals/pkg/task"
-	"github.com/genmcp/gevals/pkg/util"
+	"github.com/mcpchecker/mcpchecker/pkg/llmjudge"
+	"github.com/mcpchecker/mcpchecker/pkg/steps"
+	"github.com/mcpchecker/mcpchecker/pkg/task"
+	"github.com/mcpchecker/mcpchecker/pkg/util"
 )
 
 // shellEscapeSingleQuote escapes a string for use within single quotes in a shell command.

--- a/functional/tests/happy_path_test.go
+++ b/functional/tests/happy_path_test.go
@@ -5,7 +5,7 @@ package tests
 import (
 	"testing"
 
-	"github.com/genmcp/gevals/functional/testcase"
+	"github.com/mcpchecker/mcpchecker/functional/testcase"
 )
 
 // TestTaskPassesWithToolCallAndJudge verifies the happy path where:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/genmcp/gevals
+module github.com/mcpchecker/mcpchecker
 
 go 1.25.5
 

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/genmcp/gevals/pkg/util"
+	"github.com/mcpchecker/mcpchecker/pkg/util"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/genmcp/gevals/pkg/util"
+	"github.com/mcpchecker/mcpchecker/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/ptr"
 )

--- a/pkg/agent/openai_agent_runner.go
+++ b/pkg/agent/openai_agent_runner.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/genmcp/gevals/pkg/openaiagent"
+	"github.com/mcpchecker/mcpchecker/pkg/openaiagent"
 )
 
 // openAIAgentRunner implements Runner for OpenAI agents using the openaiagent package

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -4,12 +4,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewRootCmd creates the root geval command
+// NewRootCmd creates the root mcpchecker command
 func NewRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   "geval",
+		Use:   "mcpchecker",
 		Short: "MCP evaluation framework",
-		Long: `geval is a framework for evaluating MCP agents against tasks.
+		Long: `mcpchecker is a framework for evaluating MCP agents against tasks.
 It runs agents through defined tasks and validates their behavior using assertions.`,
 	}
 

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/genmcp/gevals/pkg/eval"
-	"github.com/genmcp/gevals/pkg/util"
+	"github.com/mcpchecker/mcpchecker/pkg/eval"
+	"github.com/mcpchecker/mcpchecker/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -52,7 +52,7 @@ func NewEvalCmd() *cobra.Command {
 			}
 
 			// Save results to JSON file
-			outputFile := fmt.Sprintf("gevals-%s-out.json", spec.Metadata.Name)
+			outputFile := fmt.Sprintf("mcpchecker-%s-out.json", spec.Metadata.Name)
 			if err := saveResultsToFile(results, outputFile); err != nil {
 				return fmt.Errorf("failed to save results to file: %w", err)
 			}

--- a/pkg/cli/view.go
+++ b/pkg/cli/view.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/genmcp/gevals/pkg/eval"
-	"github.com/genmcp/gevals/pkg/mcpproxy"
-	"github.com/genmcp/gevals/pkg/task"
+	"github.com/mcpchecker/mcpchecker/pkg/eval"
+	"github.com/mcpchecker/mcpchecker/pkg/mcpproxy"
+	"github.com/mcpchecker/mcpchecker/pkg/task"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/spf13/cobra"
 )
@@ -37,11 +37,11 @@ func NewViewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "view <results-file>",
 		Short: "Pretty-print evaluation results from a JSON file",
-		Long: `Render the JSON output produced by "geval run" in a human-friendly format.
+		Long: `Render the JSON output produced by "mcpchecker run" in a human-friendly format.
 
 Examples:
-  geval view gevals-netedge-selector-mismatch-out.json
-  geval view --task netedge-selector-mismatch --max-events 15 results.json`,
+  mcpchecker view mcpchecker-netedge-selector-mismatch-out.json
+  mcpchecker view --task netedge-selector-mismatch --max-events 15 results.json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			results, err := loadEvalResults(args[0])

--- a/pkg/eval/assert.go
+++ b/pkg/eval/assert.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/genmcp/gevals/pkg/mcpproxy"
+	"github.com/mcpchecker/mcpchecker/pkg/mcpproxy"
 )
 
 const (

--- a/pkg/eval/config.go
+++ b/pkg/eval/config.go
@@ -7,9 +7,9 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"github.com/genmcp/gevals/pkg/extension"
-	"github.com/genmcp/gevals/pkg/llmjudge"
-	"github.com/genmcp/gevals/pkg/util"
+	"github.com/mcpchecker/mcpchecker/pkg/extension"
+	"github.com/mcpchecker/mcpchecker/pkg/llmjudge"
+	"github.com/mcpchecker/mcpchecker/pkg/util"
 )
 
 const (

--- a/pkg/eval/runner.go
+++ b/pkg/eval/runner.go
@@ -7,13 +7,13 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/genmcp/gevals/pkg/agent"
-	"github.com/genmcp/gevals/pkg/extension/client"
-	"github.com/genmcp/gevals/pkg/extension/resolver"
-	"github.com/genmcp/gevals/pkg/llmjudge"
-	"github.com/genmcp/gevals/pkg/mcpproxy"
-	"github.com/genmcp/gevals/pkg/task"
-	"github.com/genmcp/gevals/pkg/util"
+	"github.com/mcpchecker/mcpchecker/pkg/agent"
+	"github.com/mcpchecker/mcpchecker/pkg/extension/client"
+	"github.com/mcpchecker/mcpchecker/pkg/extension/resolver"
+	"github.com/mcpchecker/mcpchecker/pkg/llmjudge"
+	"github.com/mcpchecker/mcpchecker/pkg/mcpproxy"
+	"github.com/mcpchecker/mcpchecker/pkg/task"
+	"github.com/mcpchecker/mcpchecker/pkg/util"
 )
 
 type EvalResult struct {

--- a/pkg/extension/client/client.go
+++ b/pkg/extension/client/client.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"sync"
 
-	"github.com/genmcp/gevals/pkg/extension/protocol"
+	"github.com/mcpchecker/mcpchecker/pkg/extension/protocol"
 	"golang.org/x/exp/jsonrpc2"
 )
 

--- a/pkg/extension/client/manager.go
+++ b/pkg/extension/client/manager.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"sync"
 
-	"github.com/genmcp/gevals/pkg/extension"
-	"github.com/genmcp/gevals/pkg/extension/protocol"
-	"github.com/genmcp/gevals/pkg/extension/resolver"
+	"github.com/mcpchecker/mcpchecker/pkg/extension"
+	"github.com/mcpchecker/mcpchecker/pkg/extension/protocol"
+	"github.com/mcpchecker/mcpchecker/pkg/extension/resolver"
 )
 
 type ExtensionManager interface {

--- a/pkg/extension/client/manager_test.go
+++ b/pkg/extension/client/manager_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/genmcp/gevals/pkg/extension"
-	"github.com/genmcp/gevals/pkg/extension/protocol"
+	"github.com/mcpchecker/mcpchecker/pkg/extension"
+	"github.com/mcpchecker/mcpchecker/pkg/extension/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/extension/resolver/github_source.go
+++ b/pkg/extension/resolver/github_source.go
@@ -30,7 +30,7 @@ func (s *GithubSource) Resolve(ctx context.Context, ref string) (string, error) 
 	}
 
 	cfg := &binarycache.Config{
-		CacheName:              fmt.Sprintf(".gevals/%s-%s", owner, repo),
+		CacheName:              fmt.Sprintf(".mcpchecker/%s-%s", owner, repo),
 		BinaryPrefix:           repo,
 		GitHubReleasesURL:      fmt.Sprintf("https://github.com/%s/%s/releases/download", owner, repo),
 		GitHubAPIURL:           fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repo),

--- a/pkg/extension/sdk/doc.go
+++ b/pkg/extension/sdk/doc.go
@@ -1,7 +1,7 @@
-// Package sdk provides a framework for building gevals extensions.
+// Package sdk provides a framework for building mcpchecker extensions.
 //
 // Extensions are JSON-RPC 2.0 servers that communicate over stdio, allowing
-// gevals to execute domain-specific operations during task setup, verification,
+// mcpchecker to execute domain-specific operations during task setup, verification,
 // and cleanup phases.
 //
 // # Creating an Extension

--- a/pkg/extension/sdk/extension.go
+++ b/pkg/extension/sdk/extension.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/genmcp/gevals/pkg/extension/protocol"
+	"github.com/mcpchecker/mcpchecker/pkg/extension/protocol"
 	"golang.org/x/exp/jsonrpc2"
 )
 

--- a/pkg/extension/sdk/helpers.go
+++ b/pkg/extension/sdk/helpers.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/genmcp/gevals/pkg/extension/protocol"
+	"github.com/mcpchecker/mcpchecker/pkg/extension/protocol"
 )
 
 // UnmarshalArgs unmarshals the operation request args into the provided type.

--- a/pkg/extension/sdk/operation.go
+++ b/pkg/extension/sdk/operation.go
@@ -3,7 +3,7 @@ package sdk
 import (
 	"context"
 
-	"github.com/genmcp/gevals/pkg/extension/protocol"
+	"github.com/mcpchecker/mcpchecker/pkg/extension/protocol"
 	"github.com/google/jsonschema-go/jsonschema"
 )
 

--- a/pkg/mcpproxy/server.go
+++ b/pkg/mcpproxy/server.go
@@ -79,7 +79,7 @@ func createProxyClient(ctx context.Context, config *ServerConfig) (*mcp.ClientSe
 	}
 
 	client := mcp.NewClient(&mcp.Implementation{
-		Name:    "gevals-proxy-client",
+		Name:    "mcpchecker-proxy-client",
 		Version: "0.0.0",
 	}, nil)
 

--- a/pkg/steps/extension.go
+++ b/pkg/steps/extension.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/genmcp/gevals/pkg/extension/client"
-	extprotocol "github.com/genmcp/gevals/pkg/extension/protocol"
+	"github.com/mcpchecker/mcpchecker/pkg/extension/client"
+	extprotocol "github.com/mcpchecker/mcpchecker/pkg/extension/protocol"
 )
 
 type extensionStep struct {

--- a/pkg/steps/llm_judge.go
+++ b/pkg/steps/llm_judge.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/genmcp/gevals/pkg/llmjudge"
-	"github.com/genmcp/gevals/pkg/util"
+	"github.com/mcpchecker/mcpchecker/pkg/llmjudge"
+	"github.com/mcpchecker/mcpchecker/pkg/util"
 )
 
 type LLMJudgeStep struct {

--- a/pkg/steps/llm_judge_test.go
+++ b/pkg/steps/llm_judge_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/genmcp/gevals/pkg/llmjudge"
+	"github.com/mcpchecker/mcpchecker/pkg/llmjudge"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/steps/script.go
+++ b/pkg/steps/script.go
@@ -108,7 +108,7 @@ func (s *ScriptStep) Execute(ctx context.Context, input *StepInput) (*StepOutput
 // Scripts with shebangs are written to temp files in the current directory to preserve relative paths.
 func (s *ScriptStep) createInlineCommand(ctx context.Context, workdir string) (*exec.Cmd, error) {
 	if strings.HasPrefix(strings.TrimSpace(s.Inline), "#!") {
-		tmpFile, err := os.CreateTemp(workdir, ".gevals-step-*.sh")
+		tmpFile, err := os.CreateTemp(workdir, ".mcpchecker-step-*.sh")
 		if err != nil {
 			return nil, fmt.Errorf("failed to create temp script file: %w", err)
 		}

--- a/pkg/task/config.go
+++ b/pkg/task/config.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/genmcp/gevals/pkg/llmjudge"
-	"github.com/genmcp/gevals/pkg/steps"
-	"github.com/genmcp/gevals/pkg/util"
+	"github.com/mcpchecker/mcpchecker/pkg/llmjudge"
+	"github.com/mcpchecker/mcpchecker/pkg/steps"
+	"github.com/mcpchecker/mcpchecker/pkg/util"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/task/config_test.go
+++ b/pkg/task/config_test.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/genmcp/gevals/pkg/steps"
-	"github.com/genmcp/gevals/pkg/util"
+	"github.com/mcpchecker/mcpchecker/pkg/steps"
+	"github.com/mcpchecker/mcpchecker/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/task/run.go
+++ b/pkg/task/run.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/genmcp/gevals/pkg/agent"
-	"github.com/genmcp/gevals/pkg/extension/client"
-	"github.com/genmcp/gevals/pkg/steps"
+	"github.com/mcpchecker/mcpchecker/pkg/agent"
+	"github.com/mcpchecker/mcpchecker/pkg/extension/client"
+	"github.com/mcpchecker/mcpchecker/pkg/steps"
 )
 
 // PhaseOutput represents the output from a task phase (setup, agent, verify, or cleanup).

--- a/pkg/task/translate.go
+++ b/pkg/task/translate.go
@@ -3,8 +3,8 @@ package task
 import (
 	"encoding/json"
 
-	"github.com/genmcp/gevals/pkg/steps"
-	"github.com/genmcp/gevals/pkg/util"
+	"github.com/mcpchecker/mcpchecker/pkg/steps"
+	"github.com/mcpchecker/mcpchecker/pkg/util"
 )
 
 func translateV1Alpha1ToSteps(legacy *TaskStepsV1Alpha1) (*TaskSpec, error) {

--- a/pkg/util/meta.go
+++ b/pkg/util/meta.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	APIVersionV1Alpha1 = "gevals/v1alpha1"
-	APIVersionV1Alpha2 = "gevals/v1alpha2"
+	APIVersionV1Alpha1 = "mcpchecker/v1alpha1"
+	APIVersionV1Alpha2 = "mcpchecker/v1alpha2"
 )
 
 type TypeMeta struct {

--- a/pkg/util/step.go
+++ b/pkg/util/step.go
@@ -46,7 +46,7 @@ func (s *Step) Run(ctx context.Context) (string, error) {
 // Scripts with shebangs are written to temp files in the current directory to preserve relative paths.
 func (s *Step) createInlineCommand(ctx context.Context) (*exec.Cmd, error) {
 	if strings.HasPrefix(strings.TrimSpace(s.Inline), "#!") {
-		tmpFile, err := os.CreateTemp(".", ".gevals-step-*.sh")
+		tmpFile, err := os.CreateTemp(".", ".mcpchecker-step-*.sh")
 		if err != nil {
 			return nil, fmt.Errorf("failed to create temp script file: %w", err)
 		}


### PR DESCRIPTION
This PR is a follow up on re-orging the repo, changing the names throughout.