### PR TITLE
docs: documented 0.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- Renamed project from gevals to mcpchecker, migrated to mcpchecker github org
 
 ### Fixed
+
+## [0.0.3]
+
+### Changed
+- Renamed project from gevals to mcpchecker, migrated to mcpchecker github org
 
 ## [0.0.2]
 


### PR DESCRIPTION
This PR adds docs for a 0.0.3 release, so that we can fix imports in other dependent repos (e.g. https://github.com/mcpchecker/kubernetes-extension).

Currently I see errors like:
```
go: finding module for package github.com/mcpchecker/mcpchecker/pkg/extension/sdk
go: downloading github.com/mcpchecker/mcpchecker v0.0.2
go: found github.com/mcpchecker/mcpchecker/pkg/extension/sdk in github.com/mcpchecker/mcpchecker v0.0.2
go: github.com/mcpchecker/kubernetes-extension/pkg/extension imports
	github.com/mcpchecker/mcpchecker/pkg/extension/sdk: github.com/mcpchecker/mcpchecker@v0.0.2: parsing go.mod:
	module declares its path as: github.com/genmcp/gevals
	       but was required as: github.com/mcpchecker/mcpchecker
```