### PR TITLE
refactor: expose full MCP tool, not just tool names from mcpproxy

### DIFF
--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -144,13 +144,13 @@ func (a *agentSpecRunner) RunTask(ctx context.Context, prompt string) (AgentResu
 
 	var allowedTools []string
 	for _, s := range a.mcpInfo.GetMcpServers() {
-		for _, t := range s.GetAllowedToolNames() {
+		for _, t := range s.GetAllowedTools() {
 			tmp := struct {
 				ServerName string
 				ToolName   string
 			}{
 				ServerName: s.GetName(),
-				ToolName:   t,
+				ToolName:   t.Name,
 			}
 
 			formatted := bytes.NewBuffer(nil)


### PR DESCRIPTION
Fixes #124 

Essentially, while working on the ACP integration I came across a scenario where the RequestPermissions flow needs the tool title, not tool name. Similarly, our current agent runner needs the tool name and not the tool title. I think just exposing the tool defs is simpler 😄 