### PR TITLE
fix(test): functional tests pass again

### DIFF
--- a/functional/tests/happy_path_test.go
+++ b/functional/tests/happy_path_test.go
@@ -148,7 +148,7 @@ func TestTaskWithLabels(t *testing.T) {
 				CallTool("kubectl_version", map[string]any{}).
 				ThenRespond("kubectl version is v1.28.0")
 		}).
-		WithTask(func(task *testcase.TaskConfig) {
+		AddTask(func(task *testcase.TaskConfig) {
 			task.Name("check-kubectl-version").
 				Easy().
 				AddLabel("suite", "kubernetes").

--- a/functional/tests/runner_multi_task_test.go
+++ b/functional/tests/runner_multi_task_test.go
@@ -5,7 +5,7 @@ package tests
 import (
 	"testing"
 
-	"github.com/genmcp/gevals/functional/testcase"
+	"github.com/mcpchecker/mcpchecker/functional/testcase"
 )
 
 // TestMultipleTasksAllPass verifies that multiple tasks can be run


### PR DESCRIPTION
Between merging #115 and #109 and the repo moving I somehow merged incompatible changes to the functional tests, causing them to fail on all other PRs. This should fix them