### PR TITLE
feat(mcpproxy): add environment variable support for MCP configuration

### DIFF
--- a/.claude/skills/create-eval/mcpConfig.md
+++ b/.claude/skills/create-eval/mcpConfig.md
@@ -1,8 +1,79 @@
 # MCP Config Reference
 
-MCP configuration files define which MCP servers to use during evaluation, including connection details and tool permissions.
+MCP configuration defines which MCP servers to use during evaluation, including connection details and tool permissions.
 
-## MCP Config Structure
+## Configuration Methods
+
+There are two ways to configure MCP servers:
+
+1. **Config file** - Specify `mcpConfigFile` in the eval definition (recommended for complex setups)
+2. **Environment variables** - Set `MCP_*` environment variables (recommended for CI/CD and single-server setups)
+
+If both are provided, the config file takes priority.
+
+## Environment Variable Configuration
+
+For simple setups or CI/CD pipelines, configure MCP using environment variables:
+
+### HTTP Server Variables
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `MCP_URL` | Full HTTP URL for MCP server | - | `http://localhost:8080/mcp` |
+| `MCP_HOST` | HTTP server host | `localhost` | `api.example.com` |
+| `MCP_PORT` | HTTP server port | - | `8080` |
+| `MCP_PATH` | HTTP path | `/mcp` | `/api/v1/mcp` |
+| `MCP_HEADERS` | JSON object of HTTP headers | - | `{"Authorization":"Bearer token"}` |
+
+Use either `MCP_URL` for a full URL, or `MCP_HOST`/`MCP_PORT`/`MCP_PATH` to build one.
+
+### Stdio Server Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `MCP_COMMAND` | Stdio server command | `npx` |
+| `MCP_ARGS` | Comma-separated or JSON array of args | `-y,@modelcontextprotocol/server-filesystem` |
+| `MCP_ENV` | JSON object of environment variables | `{"KUBECONFIG":"/path/to/config"}` |
+
+### Common Variables
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `MCP_SERVER_NAME` | Server name in config | `default` | `my-server` |
+| `MCP_ENABLE_ALL_TOOLS` | Enable all tools | `true` | `false` |
+
+### Examples
+
+**HTTP server:**
+```bash
+export MCP_URL=http://localhost:8080/mcp
+export MCP_HEADERS='{"Authorization":"Bearer my-token"}'
+```
+
+**HTTP server from components:**
+```bash
+export MCP_HOST=api.example.com
+export MCP_PORT=8080
+export MCP_PATH=/api/mcp
+```
+
+**Stdio server:**
+```bash
+export MCP_COMMAND=npx
+export MCP_ARGS='-y,@modelcontextprotocol/server-filesystem,/tmp'
+```
+
+**Stdio server with JSON args:**
+```bash
+export MCP_COMMAND=npx
+export MCP_ARGS='["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]'
+```
+
+## Config File Configuration
+
+For more complex setups with multiple servers, use a config file.
+
+### MCP Config Structure
 
 ```yaml
 mcpServers:
@@ -18,13 +89,13 @@ mcpServers:
     enableAllTools: true
 ```
 
-## Top-Level Fields
+### Top-Level Fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `mcpServers` | object | Yes | Map of server names to server configurations |
 
-## Server Configuration Fields
+### Server Configuration Fields
 
 Each server under `mcpServers` has these available fields:
 

--- a/pkg/mcpproxy/config_test.go
+++ b/pkg/mcpproxy/config_test.go
@@ -2,9 +2,11 @@ package mcpproxy
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -83,6 +85,358 @@ func TestParseConfigFile(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestConfigFromEnv(t *testing.T) {
+	// Helper to clear all MCP env vars
+	clearEnv := func() {
+		envVars := []string{
+			EnvMcpURL, EnvMcpHost, EnvMcpPort, EnvMcpPath,
+			EnvMcpCommand, EnvMcpArgs, EnvMcpEnv, EnvMcpServerName,
+			EnvMcpHeaders, EnvMcpEnableAllTools,
+		}
+		for _, v := range envVars {
+			os.Unsetenv(v)
+		}
+	}
+
+	tests := map[string]struct {
+		envVars     map[string]string
+		expected    *MCPConfig
+		expectErr   bool
+		errContains string
+	}{
+		"no env vars returns nil without error": {
+			envVars:  map[string]string{},
+			expected: nil,
+		},
+		"MCP_URL creates HTTP server": {
+			envVars: map[string]string{
+				EnvMcpURL: "http://localhost:8080/mcp",
+			},
+			expected: &MCPConfig{
+				MCPServers: map[string]*ServerConfig{
+					"default": {
+						Type:           TransportTypeHttp,
+						URL:            "http://localhost:8080/mcp",
+						EnableAllTools: true,
+					},
+				},
+			},
+		},
+		"MCP_HOST + MCP_PORT creates HTTP server": {
+			envVars: map[string]string{
+				EnvMcpHost: "example.com",
+				EnvMcpPort: "9090",
+			},
+			expected: &MCPConfig{
+				MCPServers: map[string]*ServerConfig{
+					"default": {
+						Type:           TransportTypeHttp,
+						URL:            "http://example.com:9090/mcp",
+						EnableAllTools: true,
+					},
+				},
+			},
+		},
+		"MCP_PORT only uses localhost default": {
+			envVars: map[string]string{
+				EnvMcpPort: "8080",
+			},
+			expected: &MCPConfig{
+				MCPServers: map[string]*ServerConfig{
+					"default": {
+						Type:           TransportTypeHttp,
+						URL:            "http://localhost:8080/mcp",
+						EnableAllTools: true,
+					},
+				},
+			},
+		},
+		"MCP_HOST only uses default path": {
+			envVars: map[string]string{
+				EnvMcpHost: "myserver.local",
+			},
+			expected: &MCPConfig{
+				MCPServers: map[string]*ServerConfig{
+					"default": {
+						Type:           TransportTypeHttp,
+						URL:            "http://myserver.local/mcp",
+						EnableAllTools: true,
+					},
+				},
+			},
+		},
+		"MCP_PATH customizes path": {
+			envVars: map[string]string{
+				EnvMcpHost: "localhost",
+				EnvMcpPort: "8080",
+				EnvMcpPath: "/api/v1/mcp",
+			},
+			expected: &MCPConfig{
+				MCPServers: map[string]*ServerConfig{
+					"default": {
+						Type:           TransportTypeHttp,
+						URL:            "http://localhost:8080/api/v1/mcp",
+						EnableAllTools: true,
+					},
+				},
+			},
+		},
+		"MCP_PATH without leading slash": {
+			envVars: map[string]string{
+				EnvMcpHost: "localhost",
+				EnvMcpPort: "8080",
+				EnvMcpPath: "custom/path",
+			},
+			expected: &MCPConfig{
+				MCPServers: map[string]*ServerConfig{
+					"default": {
+						Type:           TransportTypeHttp,
+						URL:            "http://localhost:8080/custom/path",
+						EnableAllTools: true,
+					},
+				},
+			},
+		},
+		"MCP_COMMAND creates stdio server": {
+			envVars: map[string]string{
+				EnvMcpCommand: "npx",
+			},
+			expected: &MCPConfig{
+				MCPServers: map[string]*ServerConfig{
+					"default": {
+						Type:           TransportTypeStdio,
+						Command:        "npx",
+						EnableAllTools: true,
+					},
+				},
+			},
+		},
+		"MCP_ARGS as comma-separated": {
+			envVars: map[string]string{
+				EnvMcpCommand: "npx",
+				EnvMcpArgs:    "-y,@modelcontextprotocol/server-filesystem,/tmp",
+			},
+			expected: &MCPConfig{
+				MCPServers: map[string]*ServerConfig{
+					"default": {
+						Type:           TransportTypeStdio,
+						Command:        "npx",
+						Args:           []string{"-y", "@modelcontextprotocol/server-filesystem", "/tmp"},
+						EnableAllTools: true,
+					},
+				},
+			},
+		},
+		"MCP_ARGS as JSON array": {
+			envVars: map[string]string{
+				EnvMcpCommand: "npx",
+				EnvMcpArgs:    `["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]`,
+			},
+			expected: &MCPConfig{
+				MCPServers: map[string]*ServerConfig{
+					"default": {
+						Type:           TransportTypeStdio,
+						Command:        "npx",
+						Args:           []string{"-y", "@modelcontextprotocol/server-filesystem", "/tmp"},
+						EnableAllTools: true,
+					},
+				},
+			},
+		},
+		"MCP_ENV parsed as JSON": {
+			envVars: map[string]string{
+				EnvMcpCommand: "npx",
+				EnvMcpEnv:     `{"KUBECONFIG":"/path/to/config","DEBUG":"true"}`,
+			},
+			expected: &MCPConfig{
+				MCPServers: map[string]*ServerConfig{
+					"default": {
+						Type:           TransportTypeStdio,
+						Command:        "npx",
+						Env:            map[string]string{"KUBECONFIG": "/path/to/config", "DEBUG": "true"},
+						EnableAllTools: true,
+					},
+				},
+			},
+		},
+		"invalid MCP_ENV returns error": {
+			envVars: map[string]string{
+				EnvMcpCommand: "npx",
+				EnvMcpEnv:     "not-json",
+			},
+			expectErr:   true,
+			errContains: "invalid MCP_ENV",
+		},
+		"MCP_HEADERS parsed as JSON": {
+			envVars: map[string]string{
+				EnvMcpURL:     "http://localhost:8080/mcp",
+				EnvMcpHeaders: `{"Authorization":"Bearer token123","X-Custom":"value"}`,
+			},
+			expected: &MCPConfig{
+				MCPServers: map[string]*ServerConfig{
+					"default": {
+						Type:           TransportTypeHttp,
+						URL:            "http://localhost:8080/mcp",
+						Headers:        map[string]string{"Authorization": "Bearer token123", "X-Custom": "value"},
+						EnableAllTools: true,
+					},
+				},
+			},
+		},
+		"invalid MCP_HEADERS returns error": {
+			envVars: map[string]string{
+				EnvMcpURL:     "http://localhost:8080/mcp",
+				EnvMcpHeaders: "not-json",
+			},
+			expectErr:   true,
+			errContains: "invalid MCP_HEADERS",
+		},
+		"MCP_SERVER_NAME customizes server name": {
+			envVars: map[string]string{
+				EnvMcpURL:        "http://localhost:8080/mcp",
+				EnvMcpServerName: "kubernetes",
+			},
+			expected: &MCPConfig{
+				MCPServers: map[string]*ServerConfig{
+					"kubernetes": {
+						Type:           TransportTypeHttp,
+						URL:            "http://localhost:8080/mcp",
+						EnableAllTools: true,
+					},
+				},
+			},
+		},
+		"MCP_ENABLE_ALL_TOOLS false": {
+			envVars: map[string]string{
+				EnvMcpURL:            "http://localhost:8080/mcp",
+				EnvMcpEnableAllTools: "false",
+			},
+			expected: &MCPConfig{
+				MCPServers: map[string]*ServerConfig{
+					"default": {
+						Type:           TransportTypeHttp,
+						URL:            "http://localhost:8080/mcp",
+						EnableAllTools: false,
+					},
+				},
+			},
+		},
+		"MCP_ENABLE_ALL_TOOLS 0": {
+			envVars: map[string]string{
+				EnvMcpURL:            "http://localhost:8080/mcp",
+				EnvMcpEnableAllTools: "0",
+			},
+			expected: &MCPConfig{
+				MCPServers: map[string]*ServerConfig{
+					"default": {
+						Type:           TransportTypeHttp,
+						URL:            "http://localhost:8080/mcp",
+						EnableAllTools: false,
+					},
+				},
+			},
+		},
+		"MCP_ENABLE_ALL_TOOLS true explicitly": {
+			envVars: map[string]string{
+				EnvMcpURL:            "http://localhost:8080/mcp",
+				EnvMcpEnableAllTools: "true",
+			},
+			expected: &MCPConfig{
+				MCPServers: map[string]*ServerConfig{
+					"default": {
+						Type:           TransportTypeHttp,
+						URL:            "http://localhost:8080/mcp",
+						EnableAllTools: true,
+					},
+				},
+			},
+		},
+		"invalid MCP_ARGS JSON returns error": {
+			envVars: map[string]string{
+				EnvMcpCommand: "npx",
+				EnvMcpArgs:    `["invalid`,
+			},
+			expectErr:   true,
+			errContains: "invalid MCP_ARGS",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			clearEnv()
+			defer clearEnv()
+
+			for k, v := range tc.envVars {
+				os.Setenv(k, v)
+			}
+
+			config, err := ConfigFromEnv()
+
+			if tc.expectErr {
+				require.Error(t, err)
+				if tc.errContains != "" {
+					assert.Contains(t, err.Error(), tc.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, config)
+		})
+	}
+}
+
+func TestParseArgs(t *testing.T) {
+	tests := map[string]struct {
+		input     string
+		expected  []string
+		expectErr bool
+	}{
+		"empty string": {
+			input:    "",
+			expected: []string{},
+		},
+		"single arg": {
+			input:    "arg1",
+			expected: []string{"arg1"},
+		},
+		"comma-separated": {
+			input:    "arg1,arg2,arg3",
+			expected: []string{"arg1", "arg2", "arg3"},
+		},
+		"comma-separated with spaces": {
+			input:    " arg1 , arg2 , arg3 ",
+			expected: []string{"arg1", "arg2", "arg3"},
+		},
+		"JSON array": {
+			input:    `["arg1", "arg2", "arg3"]`,
+			expected: []string{"arg1", "arg2", "arg3"},
+		},
+		"JSON array with special chars": {
+			input:    `["-y", "@scope/pkg", "/path/to/dir"]`,
+			expected: []string{"-y", "@scope/pkg", "/path/to/dir"},
+		},
+		"invalid JSON array": {
+			input:     `["invalid`,
+			expectErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := parseArgs(tc.input)
+
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
Make mcpConfigFile optional in eval definitions by allowing MCP server configuration via environment variables. This simplifies single-server setups and CI/CD pipelines.

Configuration priority: config file > env vars > error with guidance.

Supported environment variables:
- MCP_URL, MCP_HOST, MCP_PORT, MCP_PATH for HTTP servers
- MCP_COMMAND, MCP_ARGS, MCP_ENV for stdio servers
- MCP_SERVER_NAME, MCP_HEADERS, MCP_ENABLE_ALL_TOOLS for customization


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP configuration can be provided via environment variables; config file takes priority when both are present.

* **Documentation**
  * Docs updated with dual configuration methods, priority rules, environment-variable expansion rules, tool permission examples, and expanded HTTP/stdio examples.

* **Tests**
  * Added coverage for loading configs from files, environment, and stdio scenarios, plus argument/header parsing and validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->