### PR TITLE
fix: do not make copy of mutex in protocol.Operation

### DIFF
--- a/pkg/extension/protocol/types.go
+++ b/pkg/extension/protocol/types.go
@@ -25,11 +25,11 @@ type InitializeParams struct {
 // InitializeResult is returned form the "initialize" method
 // This is the extension manifest
 type InitializeResult struct {
-	Name            string               `json:"name"`
-	Version         string               `json:"version"`
-	ProtocolVersion string               `json:"protocolVersion"`
-	Description     string               `json:"description,omitempty"`
-	Operations      map[string]Operation `json:"operations"`
+	Name            string                `json:"name"`
+	Version         string                `json:"version"`
+	ProtocolVersion string                `json:"protocolVersion"`
+	Description     string                `json:"description,omitempty"`
+	Operations      map[string]*Operation `json:"operations"`
 }
 
 type Operation struct {

--- a/pkg/extension/sdk/extension.go
+++ b/pkg/extension/sdk/extension.go
@@ -180,9 +180,9 @@ func (e *Extension) handleInitialize(_ context.Context, req *jsonrpc2.Request) (
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	operations := make(map[string]protocol.Operation, len(e.operations))
+	operations := make(map[string]*protocol.Operation, len(e.operations))
 	for name, op := range e.operations {
-		operations[name] = protocol.Operation{
+		operations[name] = &protocol.Operation{
 			Description: op.operation.description,
 			Params:      op.operation.params,
 		}


### PR DESCRIPTION
In the `protocol.Operation` type we added a mutex. This leads to issues when assigning a local var to an operation in the operations map from the initialize result, as it makes a copy of the mutex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal operation data structure handling to improve memory efficiency and maintain consistency across protocol components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->