### PR TITLE
chore: Adding timeout on extension call steps

### DIFF
--- a/pkg/steps/extension.go
+++ b/pkg/steps/extension.go
@@ -4,9 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/mcpchecker/mcpchecker/pkg/extension/client"
 	extprotocol "github.com/mcpchecker/mcpchecker/pkg/extension/protocol"
+)
+
+const (
+	// extensionTimeout is the timeout for extension operation calls
+	extensionTimeout = 30 * time.Second
 )
 
 type extensionStep struct {
@@ -61,6 +67,10 @@ func NewExtensionParser(ctx context.Context, alias string) PrefixParser {
 var _ StepRunner = &extensionStep{}
 
 func (r *extensionStep) Execute(ctx context.Context, input *StepInput) (*StepOutput, error) {
+	// Apply timeout to prevent extension calls from hanging indefinitely
+	ctx, cancel := context.WithTimeout(ctx, extensionTimeout)
+	defer cancel()
+
 	manager, ok := client.ManagerFromContext(ctx)
 	if !ok {
 		return nil, fmt.Errorf("failed to get extension manager from context")


### PR DESCRIPTION
as per title

Noticed it got (sometimes) stuck at 

```
=== Evaluation Complete ===
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extension execution now enforces a maximum timeout, preventing calls from hanging and improving overall system stability.
  * Long-running extension operations will fail promptly, improving responsiveness and resource usage.
  * No changes to public API signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->