### PR TITLE
feat: add template substitution in llmJudge steps

### DIFF
--- a/pkg/steps/llm_judge.go
+++ b/pkg/steps/llm_judge.go
@@ -5,16 +5,21 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/genmcp/gen-mcp/pkg/template"
 	"github.com/mcpchecker/mcpchecker/pkg/llmjudge"
 	"github.com/mcpchecker/mcpchecker/pkg/util"
 )
 
+// LLMJudgeStep validates agent outputs using an LLM judge.
 type LLMJudgeStep struct {
-	cfg *llmjudge.LLMJudgeStepConfig
+	cfg              *llmjudge.LLMJudgeStepConfig
+	containsTemplate *template.TemplateBuilder
+	exactTemplate    *template.TemplateBuilder
 }
 
 var _ StepRunner = &LLMJudgeStep{}
 
+// ParseLLMJudgeStep parses an LLM judge step from JSON configuration.
 func ParseLLMJudgeStep(raw json.RawMessage) (StepRunner, error) {
 	cfg := &llmjudge.LLMJudgeStepConfig{}
 
@@ -26,14 +31,53 @@ func ParseLLMJudgeStep(raw json.RawMessage) (StepRunner, error) {
 	return NewLLMJudgeStep(cfg)
 }
 
+// NewLLMJudgeStep creates a new LLM judge step with template support.
 func NewLLMJudgeStep(cfg *llmjudge.LLMJudgeStepConfig) (*LLMJudgeStep, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 
-	return &LLMJudgeStep{cfg: cfg}, nil
+	step := &LLMJudgeStep{cfg: cfg}
+
+	// Register "steps" source factory for template parsing
+	sources := map[string]template.SourceFactory{
+		"steps": template.NewSourceFactory("steps"),
+	}
+
+	// Parse Contains field as template if present
+	if cfg.Contains != "" {
+		containsTemplate, err := template.ParseTemplate(cfg.Contains, template.TemplateParserOptions{
+			Sources: sources,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse contains template: %w", err)
+		}
+
+		step.containsTemplate, err = template.NewTemplateBuilder(containsTemplate, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create template builder for contains: %w", err)
+		}
+	}
+
+	// Parse Exact field as template if present
+	if cfg.Exact != "" {
+		exactTemplate, err := template.ParseTemplate(cfg.Exact, template.TemplateParserOptions{
+			Sources: sources,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse exact template: %w", err)
+		}
+
+		step.exactTemplate, err = template.NewTemplateBuilder(exactTemplate, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create template builder for exact: %w", err)
+		}
+	}
+
+	return step, nil
 }
 
+// Execute runs the LLM judge step with template expansion for step outputs.
 func (s *LLMJudgeStep) Execute(ctx context.Context, input *StepInput) (*StepOutput, error) {
 	judge, ok := llmjudge.FromContext(ctx)
 	if !ok {
@@ -44,11 +88,58 @@ func (s *LLMJudgeStep) Execute(ctx context.Context, input *StepInput) (*StepOutp
 		return nil, fmt.Errorf("cannot run llmJudge step before agent (must be in verification)")
 	}
 
-	if util.IsVerbose(ctx) {
-		fmt.Printf("  → LLM judge '%s' is evaluating…\n", judge.ModelName())
+	// Register step outputs as a template source
+	// Always register if templates exist to ensure consistent error handling
+	// and prevent resolver state leakage between executions
+	stepOutputs := input.StepOutputs
+	if stepOutputs == nil {
+		stepOutputs = make(map[string]map[string]string)
 	}
 
-	res, err := judge.EvaluateText(ctx, s.cfg, input.Agent.Prompt, input.Agent.Output)
+	resolver := NewStepOutputResolver(stepOutputs)
+	if s.containsTemplate != nil {
+		s.containsTemplate.SetSourceResolver("steps", resolver)
+	}
+	if s.exactTemplate != nil {
+		s.exactTemplate.SetSourceResolver("steps", resolver)
+	}
+
+	// Resolve templates to get final values
+	// Clone the config to preserve all fields (model, temperature, rubric, etc.)
+	expandedCfg := *s.cfg
+
+	if s.containsTemplate != nil {
+		result, err := s.containsTemplate.GetResult()
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve contains template: %w", err)
+		}
+		str, ok := result.(string)
+		if !ok {
+			return nil, fmt.Errorf("contains template resolved to non-string type: %T", result)
+		}
+		expandedCfg.Contains = str
+	}
+
+	if s.exactTemplate != nil {
+		result, err := s.exactTemplate.GetResult()
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve exact template: %w", err)
+		}
+		str, ok := result.(string)
+		if !ok {
+			return nil, fmt.Errorf("exact template resolved to non-string type: %T", result)
+		}
+		expandedCfg.Exact = str
+	}
+
+	if util.IsVerbose(ctx) {
+		fmt.Printf("  → LLM judge '%s' is evaluating…\n", judge.ModelName())
+		if expandedCfg.Contains != s.cfg.Contains || expandedCfg.Exact != s.cfg.Exact {
+			fmt.Printf("  → Template expansion: %s -> %s\n", s.cfg.ReferenceAnswer(), expandedCfg.ReferenceAnswer())
+		}
+	}
+
+	res, err := judge.EvaluateText(ctx, &expandedCfg, input.Agent.Prompt, input.Agent.Output)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call llm judge: %w", err)
 	}
@@ -64,4 +155,48 @@ func (s *LLMJudgeStep) Execute(ctx context.Context, input *StepInput) (*StepOutp
 	}
 
 	return out, nil
+}
+
+// StepOutputResolver resolves template variables from step outputs.
+// It implements the template.SourceResolver interface.
+type StepOutputResolver struct {
+	outputs map[string]map[string]string
+}
+
+// NewStepOutputResolver creates a new resolver for step outputs.
+func NewStepOutputResolver(outputs map[string]map[string]string) *StepOutputResolver {
+	return &StepOutputResolver{outputs: outputs}
+}
+
+// Resolve looks up a field in the step outputs.
+// Field names use the format "stepType.outputKey" where stepType can contain dots.
+// Example: "kubernetes.listContexts.current" looks up outputs["kubernetes.listContexts"]["current"]
+func (r *StepOutputResolver) Resolve(fieldName string) (string, error) {
+	// Split on the last dot to separate stepType from outputKey
+	lastDot := -1
+	for i := len(fieldName) - 1; i >= 0; i-- {
+		if fieldName[i] == '.' {
+			lastDot = i
+			break
+		}
+	}
+
+	if lastDot == -1 {
+		return "", fmt.Errorf("invalid field name %q: must be in format stepType.outputKey", fieldName)
+	}
+
+	stepType := fieldName[:lastDot]  // e.g., "kubernetes.listContexts"
+	outputKey := fieldName[lastDot+1:] // e.g., "current"
+
+	stepOutputs, ok := r.outputs[stepType]
+	if !ok {
+		return "", fmt.Errorf("step type %q not found in outputs", stepType)
+	}
+
+	value, ok := stepOutputs[outputKey]
+	if !ok {
+		return "", fmt.Errorf("output key %q not found for step type %q", outputKey, stepType)
+	}
+
+	return value, nil
 }

--- a/pkg/steps/llm_judge_template_test.go
+++ b/pkg/steps/llm_judge_template_test.go
@@ -1,0 +1,264 @@
+package steps
+
+import (
+	"testing"
+
+	"github.com/mcpchecker/mcpchecker/pkg/llmjudge"
+)
+
+func TestLLMJudgeStep_TemplateExpansion(t *testing.T) {
+	tests := []struct {
+		name        string
+		contains    string
+		exact       string
+		stepOutputs map[string]map[string]string
+		wantContains string
+		wantExact    string
+		expectErr    bool
+	}{
+		{
+			name:     "single template substitution in contains",
+			contains: "current context is {steps.kubernetes.listContexts.current}",
+			stepOutputs: map[string]map[string]string{
+				"kubernetes.listContexts": {
+					"current": "kind-kind",
+					"count":   "3",
+				},
+			},
+			wantContains: "current context is kind-kind",
+		},
+		{
+			name:     "multiple template substitutions",
+			contains: "current context is {steps.kubernetes.listContexts.current} with {steps.kubernetes.listContexts.count} contexts",
+			stepOutputs: map[string]map[string]string{
+				"kubernetes.listContexts": {
+					"current": "kind-kind",
+					"count":   "3",
+				},
+			},
+			wantContains: "current context is kind-kind with 3 contexts",
+		},
+		{
+			name:     "template not found - error",
+			contains: "current context is {steps.kubernetes.listContexts.missing}",
+			stepOutputs: map[string]map[string]string{
+				"kubernetes.listContexts": {
+					"current": "kind-kind",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:     "step type not found - error",
+			contains: "value is {steps.unknown.step.field}",
+			stepOutputs: map[string]map[string]string{
+				"kubernetes.listContexts": {
+					"current": "kind-kind",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:         "text without templates",
+			contains:     "no templates here",
+			stepOutputs:  map[string]map[string]string{},
+			wantContains: "no templates here",
+		},
+		{
+			name:     "multiple different step outputs",
+			contains: "context {steps.kubernetes.getCurrentContext.context} has {steps.kubernetes.viewConfig.config}",
+			stepOutputs: map[string]map[string]string{
+				"kubernetes.getCurrentContext": {
+					"context": "production",
+				},
+				"kubernetes.viewConfig": {
+					"config": "apiVersion: v1...",
+				},
+			},
+			wantContains: "context production has apiVersion: v1...",
+		},
+		{
+			name:     "templates with special characters in values",
+			contains: "config: {steps.kubernetes.viewConfig.config}",
+			stepOutputs: map[string]map[string]string{
+				"kubernetes.viewConfig": {
+					"config": "server: https://example.com:6443",
+				},
+			},
+			wantContains: "config: server: https://example.com:6443",
+		},
+		{
+			name:     "exact field with template",
+			exact:    "The current context is {steps.kubernetes.listContexts.current}",
+			stepOutputs: map[string]map[string]string{
+				"kubernetes.listContexts": {
+					"current": "kind-kind",
+				},
+			},
+			wantExact: "The current context is kind-kind",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create LLM judge step
+			cfg := &llmjudge.LLMJudgeStepConfig{
+				Contains: tt.contains,
+				Exact:    tt.exact,
+			}
+
+			step, err := NewLLMJudgeStep(cfg)
+			if err != nil {
+				t.Fatalf("NewLLMJudgeStep() unexpected error = %v", err)
+			}
+
+			// Register step outputs as source
+			if step.containsTemplate != nil && tt.stepOutputs != nil {
+				resolver := NewStepOutputResolver(tt.stepOutputs)
+				step.containsTemplate.SetSourceResolver("steps", resolver)
+			}
+			if step.exactTemplate != nil && tt.stepOutputs != nil {
+				resolver := NewStepOutputResolver(tt.stepOutputs)
+				step.exactTemplate.SetSourceResolver("steps", resolver)
+			}
+
+			// Resolve templates
+			if step.containsTemplate != nil {
+				result, err := step.containsTemplate.GetResult()
+				if tt.expectErr {
+					if err == nil {
+						t.Errorf("GetResult() expected error, got nil")
+					}
+					return
+				}
+				if err != nil {
+					t.Errorf("GetResult() unexpected error = %v", err)
+					return
+				}
+				if result != tt.wantContains {
+					t.Errorf("GetResult() = %q, want %q", result, tt.wantContains)
+				}
+			}
+
+			if step.exactTemplate != nil {
+				result, err := step.exactTemplate.GetResult()
+				if tt.expectErr {
+					if err == nil {
+						t.Errorf("GetResult() expected error, got nil")
+					}
+					return
+				}
+				if err != nil {
+					t.Errorf("GetResult() unexpected error = %v", err)
+					return
+				}
+				if result != tt.wantExact {
+					t.Errorf("GetResult() = %q, want %q", result, tt.wantExact)
+				}
+			}
+		})
+	}
+}
+
+func TestStepOutputResolver(t *testing.T) {
+	stepOutputs := map[string]map[string]string{
+		"kubernetes.listContexts": {
+			"current": "kind-kind",
+			"count":   "3",
+		},
+		"kubernetes.getCurrentContext": {
+			"context": "production",
+		},
+	}
+
+	resolver := NewStepOutputResolver(stepOutputs)
+
+	tests := []struct {
+		name      string
+		fieldName string
+		want      string
+		expectErr bool
+	}{
+		{
+			name:      "resolve existing field",
+			fieldName: "kubernetes.listContexts.current",
+			want:      "kind-kind",
+		},
+		{
+			name:      "resolve field with different step",
+			fieldName: "kubernetes.getCurrentContext.context",
+			want:      "production",
+		},
+		{
+			name:      "missing output key",
+			fieldName: "kubernetes.listContexts.missing",
+			expectErr: true,
+		},
+		{
+			name:      "missing step type",
+			fieldName: "unknown.step.field",
+			expectErr: true,
+		},
+		{
+			name:      "invalid field name - no dot",
+			fieldName: "nodot",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := resolver.Resolve(tt.fieldName)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Resolve() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Resolve() unexpected error = %v", err)
+				return
+			}
+			if result != tt.want {
+				t.Errorf("Resolve() = %q, want %q", result, tt.want)
+			}
+		})
+	}
+}
+
+func TestLLMJudgeStep_Execute_WithTemplates(t *testing.T) {
+	// This is an integration test that would require a mock LLM judge
+	// For now, we just test that templates are properly registered and resolved
+	cfg := &llmjudge.LLMJudgeStepConfig{
+		Contains: "context is {steps.kubernetes.listContexts.current}",
+	}
+
+	step, err := NewLLMJudgeStep(cfg)
+	if err != nil {
+		t.Fatalf("NewLLMJudgeStep() error = %v", err)
+	}
+
+	// Verify template was created
+	if step.containsTemplate == nil {
+		t.Error("Expected containsTemplate to be created")
+	}
+
+	// Verify we can register a resolver
+	stepOutputs := map[string]map[string]string{
+		"kubernetes.listContexts": {
+			"current": "kind-kind",
+		},
+	}
+	resolver := NewStepOutputResolver(stepOutputs)
+	step.containsTemplate.SetSourceResolver("steps", resolver)
+
+	// Verify template resolves correctly
+	result, err := step.containsTemplate.GetResult()
+	if err != nil {
+		t.Errorf("GetResult() error = %v", err)
+	}
+	expected := "context is kind-kind"
+	if result != expected {
+		t.Errorf("GetResult() = %q, want %q", result, expected)
+	}
+}

--- a/pkg/steps/step.go
+++ b/pkg/steps/step.go
@@ -22,9 +22,10 @@ type StepRunner interface {
 }
 
 type StepInput struct {
-	Env     map[string]string
-	Workdir string
-	Agent   *AgentContext
+	Env         map[string]string
+	Workdir     string
+	Agent       *AgentContext
+	StepOutputs map[string]map[string]string // Maps step type to its outputs
 }
 
 type StepOutput struct {

--- a/pkg/task/run.go
+++ b/pkg/task/run.go
@@ -140,9 +140,12 @@ func (r *taskRunner) Setup(ctx context.Context) (*PhaseOutput, error) {
 		Success: true,
 	}
 
+	stepOutputs := make(map[string]map[string]string)
+
 	for i, s := range r.setup {
 		res, err := s.Execute(ctx, &steps.StepInput{
-			Workdir: r.baseDir,
+			Workdir:     r.baseDir,
+			StepOutputs: stepOutputs,
 		})
 
 		out.Steps = append(out.Steps, res)
@@ -153,6 +156,11 @@ func (r *taskRunner) Setup(ctx context.Context) (*PhaseOutput, error) {
 		}
 		if res != nil && !res.Success {
 			out.Success = false
+		}
+
+		// Accumulate outputs from this step
+		if res != nil && res.Success && len(res.Outputs) > 0 && res.Type != "" {
+			stepOutputs[res.Type] = res.Outputs
 		}
 	}
 
@@ -165,9 +173,12 @@ func (r *taskRunner) Cleanup(ctx context.Context) (*PhaseOutput, error) {
 		Success: true,
 	}
 
+	stepOutputs := make(map[string]map[string]string)
+
 	for i, s := range r.cleanup {
 		res, err := s.Execute(ctx, &steps.StepInput{
-			Workdir: r.baseDir,
+			Workdir:     r.baseDir,
+			StepOutputs: stepOutputs,
 		})
 
 		out.Steps = append(out.Steps, res)
@@ -178,6 +189,11 @@ func (r *taskRunner) Cleanup(ctx context.Context) (*PhaseOutput, error) {
 		}
 		if res != nil && !res.Success {
 			out.Success = false
+		}
+
+		// Accumulate outputs from this step
+		if res != nil && res.Success && len(res.Outputs) > 0 && res.Type != "" {
+			stepOutputs[res.Type] = res.Outputs
 		}
 	}
 
@@ -225,13 +241,16 @@ func (r *taskRunner) Verify(ctx context.Context) (*PhaseOutput, error) {
 		Success: true,
 	}
 
+	stepOutputs := make(map[string]map[string]string)
+
 	for i, s := range r.verify {
 		res, err := s.Execute(ctx, &steps.StepInput{
 			Agent: &steps.AgentContext{
 				Prompt: r.prompt,
 				Output: r.output,
 			},
-			Workdir: r.baseDir,
+			Workdir:     r.baseDir,
+			StepOutputs: stepOutputs,
 		})
 
 		out.Steps = append(out.Steps, res)
@@ -242,6 +261,11 @@ func (r *taskRunner) Verify(ctx context.Context) (*PhaseOutput, error) {
 		}
 		if res != nil && !res.Success {
 			out.Success = false
+		}
+
+		// Accumulate outputs from this step
+		if res != nil && res.Success && len(res.Outputs) > 0 && res.Type != "" {
+			stepOutputs[res.Type] = res.Outputs
 		}
 	}
 


### PR DESCRIPTION
  Enables llmJudge steps to reference extension operation outputs for stronger validation.

  ## Changes

  - Add `StepOutputs` field to `StepInput` to pass accumulated outputs between steps
  - Update `Setup()`, `Verify()`, and `Cleanup()` to accumulate step outputs
  - Implement `StepOutputResolver` as a custom `template.SourceResolver`
  - Uses existing **gen-mcp template package** (same pattern as http.go)
  - Add comprehensive test coverage

  ## Template Syntax

  ```yaml
  verify:
    - kubernetes.listContexts:
        # Returns: {current: "kind-kind", count: "3"}

    - llmJudge:
        contains: "{steps.kubernetes.listContexts.current}"
        # Expands to "kind-kind" - validates agent communicated actual value
  ```

  **Before vs After**

  **Before**: Generic validation only
  ```yaml
  - llmJudge:
      contains: "Kubernetes contexts"  # Too vague
  ```

  **After**: Validate actual values
  ```yaml
  - kubernetes.listContexts:  # Returns {count: "3"}
  - llmJudge:
      contains: "{steps.kubernetes.listContexts.count} context"
      # Validates agent said "3 contexts"
  ```

  Fixes #100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LLM judge supports template-driven expansion using prior step outputs, enabling dynamic Contains/Exact checks during evaluation.
  * Step outputs are propagated within each phase so later steps can reference earlier step data.

* **Bug Fixes**
  * Unresolved templates now produce errors and expanded configuration is used for evaluation; verbose logs can show expansion results.

* **Tests**
  * Added comprehensive tests for template expansion, cross-step substitutions, error cases, and edge inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->