### PR TITLE
docs: add 0.0.5 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.0.5]
+
+### Added
+- ACP (Agent Control Protocol) client library (#113)
+- ACP runner for agents (#134)
+- ACP support for builtin OpenAI agent (#164)
+- Template substitution in llmJudge steps (#170)
+- IDs for all task steps (#171)
+- Environment variable support for MCP configuration (#131)
+- 'as' alias support for task definitions (#140)
+
+### Changed
+- Timeout configuration on extension call steps (#169)
+- Refactored MCP client management to dedicated package for more reliable connections and lifecycle handling (#144)
+
+### Fixed
+- Mutex copy issue in protocol.Operation (#143)
+- Release workflows handle backticks in changelog (#137)
+
 ## [0.0.4]
 
 ### Added


### PR DESCRIPTION
In prep for a 0.0.5 release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ACP client library and agent runner
  * Added ACP support for builtin OpenAI agents
  * Added template substitution in llmJudge steps
  * Added IDs for all task steps
  * Added environment variable support for MCP configuration
  * Added 'as' alias support for task definitions

* **Changed**
  * Updated timeout configuration on extension call steps
  * Improved MCP client management

* **Bug Fixes**
  * Fixed mutex copy issue in protocol operations
  * Fixed release workflow handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->