### PR TITLE
fix(ci): setup action uses correct syntax

### DIFF
--- a/.github/actions/mcpchecker-action/action.yaml
+++ b/.github/actions/mcpchecker-action/action.yaml
@@ -124,7 +124,7 @@ runs:
 
     - name: Setup mcpchecker
       id: setup
-      uses: mcpchecker/mcpchecker/.github/actions/setup-mcpchecker@${{ github.action_ref || 'main' }}
+      uses: mcpchecker/mcpchecker/.github/actions/setup-mcpchecker@main
       with:
         version: ${{ steps.version.outputs.version }}
 


### PR DESCRIPTION
From running mcpchecker in kubernetes-mcp-server it seems like our "uses" section has invalid syntax. I believe the "uses" section has to be a static string. https://github.com/containers/kubernetes-mcp-server/actions/runs/21677714661/job/62502903943

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions configuration to consistently pin the mcpchecker setup action to the 'main' version, removing dynamic version selection logic from the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->