### PR TITLE
fix(release): goreleaser properly handles prerelease tags

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,11 @@
 version: 2
 
+git:
+  tag_sort: -version:refname
+  prerelease_suffix: "-"
+  ignore_tags:
+    - nightly
+
 builds:
   - id: mcpchecker
     main: ./cmd/mcpchecker


### PR DESCRIPTION
We saw our v0.0.6 release failing as goreleaser was defaulting to picking the prerelease tag, not the actual release tag (multiple tags on same commit).

From reading over the docs, I _think_ this will fix our config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and release configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->