### PR TITLE
fix(actions): use correct binary names from zip archives

### DIFF
--- a/.github/actions/setup-mcpchecker/action.yaml
+++ b/.github/actions/setup-mcpchecker/action.yaml
@@ -126,11 +126,11 @@ runs:
         # Extract zips
         echo "Extracting mcpchecker..."
         unzip -q "$DOWNLOAD_DIR/mcpchecker.zip" -d "$DOWNLOAD_DIR"
-        mv "$DOWNLOAD_DIR/mcpchecker-$BINARY_SUFFIX$BIN_EXT" "$MCPCHECKER_BIN"
+        mv "$DOWNLOAD_DIR/mcpchecker$BIN_EXT" "$MCPCHECKER_BIN"
 
         echo "Extracting agent..."
         unzip -q "$DOWNLOAD_DIR/agent.zip" -d "$DOWNLOAD_DIR"
-        mv "$DOWNLOAD_DIR/agent-$BINARY_SUFFIX$BIN_EXT" "$AGENT_BIN"
+        mv "$DOWNLOAD_DIR/agent$BIN_EXT" "$AGENT_BIN"
 
         chmod +x "$MCPCHECKER_BIN" "$AGENT_BIN"
         rm -rf "$DOWNLOAD_DIR"


### PR DESCRIPTION
The goreleaser configuration packages binaries without the platform suffix inside the archive. The zip file is named `mcpchecker-linux-amd64.zip` but the binary inside is just named `mcpchecker`, not `mcpchecker-linux-amd64`.       
                                                                                                                      
This was causing the `setup-mcpchecker` action to fail with:
```                                                
mv: cannot stat '/home/runner/work/_temp/mcpchecker-download/mcpchecker-linux-amd64': No such file or directory
```                                                                                                                   

**Affected Downstream Projects**                                                          
                                                                                                                      
This is blocking scheduled evaluation pipelines in projects using mcpchecker-action, for example:                   
  - https://github.com/containers/kubernetes-mcp-server/actions/runs/21820226139/job/62951418202      

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized binary extraction and naming in the build setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->