### PR TITLE
fix: check if verify is not empty

### DIFF
--- a/pkg/task/config.go
+++ b/pkg/task/config.go
@@ -117,21 +117,23 @@ func Read(data []byte, basePath string) (*TaskConfig, error) {
 	spec.basePath = basePath
 
 	if wrapper.GetAPIVersion() == util.APIVersionV1Alpha1 {
-		if wrapper.Steps == nil {
+		s := wrapper.Steps
+		if s == nil {
 			return nil, fmt.Errorf("v1alpha1 requires steps field")
 		}
 
-		if err := resolveStepPath(wrapper.Steps.SetupScript, basePath); err != nil {
+		if err := resolveStepPath(s.SetupScript, basePath); err != nil {
 			return nil, fmt.Errorf("failed to resolve setup script path: %w", err)
 		}
-		if err := resolveStepPath(wrapper.Steps.CleanupScript, basePath); err != nil {
+		if err := resolveStepPath(s.CleanupScript, basePath); err != nil {
 			return nil, fmt.Errorf("failed to resolve cleanup script path: %w", err)
 		}
-		if err := resolveStepPath(wrapper.Steps.VerifyScript.Step, basePath); err != nil {
-			return nil, fmt.Errorf("failed to resolve verify script path: %w", err)
+		if !s.VerifyScript.IsEmpty() {
+			if err := resolveStepPath(s.VerifyScript.Step, basePath); err != nil {
+				return nil, fmt.Errorf("failed to resolve verify script path: %w", err)
+			}
 		}
-
-		spec.Spec, err = translateV1Alpha1ToSteps(wrapper.Steps)
+		spec.Spec, err = translateV1Alpha1ToSteps(s)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert v1alpha1 format to v1alpha1: %w", err)
 		}

--- a/pkg/task/config_test.go
+++ b/pkg/task/config_test.go
@@ -37,6 +37,42 @@ func TestFromFile(t *testing.T) {
 		expected  *TaskConfig
 		expectErr bool
 	}{
+		"create pod inline no verify": {
+			file: "create-pod-inline-no-verify.yaml",
+			expected: &TaskConfig{
+				TypeMeta: util.TypeMeta{
+					Kind: KindTask,
+				},
+				Metadata: TaskMetadata{
+					Name:       "create pod inline",
+					Difficulty: DifficultyEasy,
+				},
+				Spec: &TaskSpec{
+					Setup: []*steps.StepConfig{{
+						Config: map[string]json.RawMessage{
+							"script": mustMarshalStep(&util.Step{
+								Inline: `#!/usr/bin/env bash
+kubectl delete namespace create-pod-test --ignore-not-found
+kubectl create namespace create-pod-test`,
+							}),
+						},
+					}},
+					Cleanup: []*steps.StepConfig{{
+						Config: map[string]json.RawMessage{
+							"script": mustMarshalStep(&util.Step{
+								Inline: `#!/usr/bin/env bash
+kubectl delete pod web-server -n create-pod-test --ignore-not-found
+kubectl delete namespace create-pod-test --ignore-not-found`,
+							}),
+						},
+					}},
+					Prompt: &util.Step{
+						Inline: "Please create a nginx pod named web-server in the create-pod-test namespace",
+					},
+				},
+				basePath: basePath,
+			},
+		},
 		"create pod inline": {
 			file: "create-pod-inline.yaml",
 			expected: &TaskConfig{

--- a/pkg/task/testdata/create-pod-inline-no-verify.yaml
+++ b/pkg/task/testdata/create-pod-inline-no-verify.yaml
@@ -1,0 +1,17 @@
+kind: Task
+metadata:
+  name: "create pod inline"
+  difficulty: easy
+steps:
+  setup:
+    inline: |-
+      #!/usr/bin/env bash
+      kubectl delete namespace create-pod-test --ignore-not-found
+      kubectl create namespace create-pod-test
+  cleanup:
+    inline: |-
+      #!/usr/bin/env bash
+      kubectl delete pod web-server -n create-pod-test --ignore-not-found
+      kubectl delete namespace create-pod-test --ignore-not-found
+  prompt:
+    inline: Please create a nginx pod named web-server in the create-pod-test namespace


### PR DESCRIPTION
This PR fixes a panic that occurs when verify is nil.

Fixes: https://github.com/mcpchecker/mcpchecker/issues/186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks can now be created without verification steps.

* **Tests**
  * Added test case for task configuration scenarios without verification requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->