### PR TITLE
fix(eval): skip non-task files in taskset glob patterns

### DIFF
--- a/pkg/eval/runner.go
+++ b/pkg/eval/runner.go
@@ -249,6 +249,10 @@ func (r *evalRunner) collectTaskConfigs(rx *regexp.Regexp) ([]taskConfig, error)
 		for _, path := range paths {
 			taskSpec, err := task.FromFile(path)
 			if err != nil {
+				// Skip files that are not tasks (e.g., eval.yaml files in the same directory)
+				if errors.Is(err, util.ErrWrongKind) {
+					continue
+				}
 				return nil, fmt.Errorf("failed to load task at path %s: %w", path, err)
 			}
 

--- a/pkg/util/meta.go
+++ b/pkg/util/meta.go
@@ -10,6 +10,9 @@ const (
 	APIVersionV1Alpha2 = "mcpchecker/v1alpha2"
 )
 
+// ErrWrongKind indicates the YAML file has a different kind than expected
+var ErrWrongKind = errors.New("wrong kind")
+
 type TypeMeta struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 	Kind       string `json:"kind"`
@@ -27,7 +30,7 @@ func (t *TypeMeta) Validate(expectedKind string) error {
 	var err error
 	err = errors.Join(err, ValidateAPIVersion(t.APIVersion))
 	if t.Kind != expectedKind {
-		err = errors.Join(err, fmt.Errorf("invalid kind '%s': expected '%s'", t.Kind, expectedKind))
+		err = errors.Join(err, fmt.Errorf("%w: got '%s', expected '%s'", ErrWrongKind, t.Kind, expectedKind))
 	}
 
 	return err


### PR DESCRIPTION
The eval runner now skips files that don't have `kind: Task` instead of failing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in task loading to gracefully skip non-task files in directories, preventing failures when configuration files and other non-task files are present alongside task files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->