### PR TITLE
feat(token usage): Add token usage for OpenAI calls

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -88,7 +88,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	return runLegacy(ctx, agentInstance, prompt)
 }
 
-func runLegacy(ctx context.Context, agent openaiagent.Agent, prompt string) error {
+func runLegacy(ctx context.Context, agent *openaiagent.AIAgent, prompt string) error {
 	result, err := agent.Run(ctx, prompt)
 	if err != nil {
 		return fmt.Errorf("agent execution failed: %w", err)

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coder/acp-go-sdk"
 	"github.com/mcpchecker/mcpchecker/pkg/mcpproxy"
 	"github.com/mcpchecker/mcpchecker/pkg/tokenizer"
+	"github.com/mcpchecker/mcpchecker/pkg/usage"
 )
 
 // TokenSource indicates where token counts came from.
@@ -52,6 +53,19 @@ type ActualUsage struct {
 	ThoughtTokens     *int64 `json:"thoughtTokens,omitempty"`
 	CachedReadTokens  *int64 `json:"cachedReadTokens,omitempty"`
 	CachedWriteTokens *int64 `json:"cachedWriteTokens,omitempty"`
+}
+
+// GetActualUsageFromTokenUsage converts token usage from internal struct to agent actual usage.
+func GetActualUsageFromTokenUsage(tokenUsage *usage.TokenUsage) *ActualUsage {
+	if tokenUsage == nil {
+		return nil
+	}
+
+	return &ActualUsage{
+		InputTokens:  int64(tokenUsage.GetInput()),
+		OutputTokens: int64(tokenUsage.GetOutput()),
+		TotalTokens:  int64(tokenUsage.GetInput() + tokenUsage.GetOutput()),
+	}
 }
 
 // TokenEstimate provides token count estimates for different components.

--- a/pkg/cli/view.go
+++ b/pkg/cli/view.go
@@ -129,6 +129,8 @@ func printEvalResult(result *eval.EvalResult, opts viewOptions) {
 
 	printAssertions(result.AssertionResults, yellow)
 	printTokenEstimate(result.TokenEstimate)
+	printActualAgentTokenUsage(result.TokenEstimate)
+	printJudgeTokenUsage(result.JudgeTokenUsage)
 	printCallHistory(result.CallHistory, opts)
 
 	if opts.showTimeline {
@@ -148,7 +150,7 @@ func printTokenEstimate(estimate *agent.TokenEstimate) {
 		return
 	}
 
-	fmt.Printf("  Tokens: ~%d (in=~%d, out=~%d)",
+	fmt.Printf("  Estimated Tokens: ~%d (in=~%d, out=~%d)",
 		estimate.TotalTokens, estimate.InputTokens, estimate.OutputTokens)
 	if estimate.Error != "" {
 		fmt.Printf(" [incomplete - %s]", estimate.Error)
@@ -174,6 +176,25 @@ func printTokenEstimate(estimate *agent.TokenEstimate) {
 		}
 	}
 	fmt.Println()
+}
+
+func printActualAgentTokenUsage(estimate *agent.TokenEstimate) {
+	if estimate == nil || estimate.Source != agent.TokenSourceActual || estimate.Actual == nil {
+		return
+	}
+
+	agentTokenUsage := estimate.Actual
+	if agentTokenUsage.InputTokens > 0 || agentTokenUsage.OutputTokens > 0 {
+		fmt.Printf("  Agent Tokens: %d (in=%d, out=%d)", agentTokenUsage.TotalTokens, agentTokenUsage.InputTokens, agentTokenUsage.OutputTokens)
+		fmt.Println()
+	}
+}
+
+func printJudgeTokenUsage(judgeTokenUsage *agent.ActualUsage) {
+	if judgeTokenUsage != nil && (judgeTokenUsage.InputTokens > 0 || judgeTokenUsage.OutputTokens > 0) {
+		fmt.Printf("  Judge Tokens: %d (in=%d, out=%d)", judgeTokenUsage.TotalTokens, judgeTokenUsage.InputTokens, judgeTokenUsage.OutputTokens)
+		fmt.Println()
+	}
 }
 
 // printAssertions prints assertion counts and any failing assertion reasons.

--- a/pkg/llmjudge/llmjudge.go
+++ b/pkg/llmjudge/llmjudge.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/openai/openai-go/v2"
 	"github.com/openai/openai-go/v2/option"
+
+	"github.com/mcpchecker/mcpchecker/pkg/usage"
 )
 
 const (
@@ -51,9 +53,10 @@ type LLMJudge interface {
 }
 
 type LLMJudgeResult struct {
-	Passed          bool   `json:"passed"`
-	Reason          string `json:"reason"`
-	FailureCategory string `json:"failureCategory"`
+	Passed          bool              `json:"passed"`
+	Reason          string            `json:"reason"`
+	FailureCategory string            `json:"failureCategory"`
+	Usage           *usage.TokenUsage `json:"usage,omitempty"`
 }
 
 type llmJudge struct {
@@ -191,6 +194,8 @@ func (j *llmJudge) EvaluateText(ctx context.Context, judgeConfig *LLMJudgeStepCo
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshall '%s' tool call arguments: %w", submitJudgementFunction.Name, err)
 	}
+
+	result.Usage = usage.FromOpenAIUsage(completion.Usage)
 
 	return result, nil
 }

--- a/pkg/steps/llm_judge.go
+++ b/pkg/steps/llm_judge.go
@@ -155,6 +155,7 @@ func (s *LLMJudgeStep) Execute(ctx context.Context, input *StepInput) (*StepOutp
 		Type:    "llmJudge",
 		Success: res.Passed,
 		Message: res.Reason,
+		Usage:   res.Usage,
 	}
 
 	if !res.Passed {

--- a/pkg/steps/step.go
+++ b/pkg/steps/step.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"time"
+
+	"github.com/mcpchecker/mcpchecker/pkg/usage"
 )
 
 const (
@@ -30,11 +32,12 @@ type StepInput struct {
 }
 
 type StepOutput struct {
-	Type    string            `json:"type,omitempty"`
-	Success bool              `json:"success"`
-	Message string            `json:"message,omitempty"`
-	Outputs map[string]string `json:"outputs,omitempty"`
-	Error   string            `json:"error,omitempty"`
+	Type    string              `json:"type,omitempty"`
+	Success bool                `json:"success"`
+	Message string              `json:"message,omitempty"`
+	Outputs map[string]string   `json:"outputs,omitempty"`
+	Error   string              `json:"error,omitempty"`
+	Usage   *usage.TokenUsage   `json:"usage,omitempty"`
 }
 
 type AgentContext struct {

--- a/pkg/usage/token.go
+++ b/pkg/usage/token.go
@@ -1,0 +1,55 @@
+package usage
+
+import (
+	"sync"
+
+	"github.com/openai/openai-go/v2"
+)
+
+// TokenUsage tracks token consumption across one or more API calls.
+type TokenUsage struct {
+	mu sync.Mutex
+
+	input  int
+	output int
+}
+
+func (u *TokenUsage) GetInput() int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	return u.input
+}
+
+func (u *TokenUsage) GetOutput() int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	return u.output
+}
+
+// Add combines another TokenUsage into this one.
+func (u *TokenUsage) Add(other *TokenUsage) {
+	if other == nil {
+		return
+	}
+
+	other.mu.Lock()
+	otherInput := other.input
+	otherOutput := other.output
+	other.mu.Unlock()
+
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	u.input += otherInput
+	u.output += otherOutput
+}
+
+// FromOpenAIUsage converts OpenAI SDK usage to TokenUsage.
+func FromOpenAIUsage(openaiUsage openai.CompletionUsage) *TokenUsage {
+	return &TokenUsage{
+		input:  int(openaiUsage.PromptTokens),
+		output: int(openaiUsage.CompletionTokens),
+	}
+}

--- a/pkg/usage/token_test.go
+++ b/pkg/usage/token_test.go
@@ -1,0 +1,131 @@
+package usage
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenUsageAdd(t *testing.T) {
+	testCases := map[string]struct {
+		initial  *TokenUsage
+		toAdd    []*TokenUsage
+		expected *TokenUsage
+	}{
+		"single addition": {
+			initial: &TokenUsage{},
+			toAdd: []*TokenUsage{
+				{
+					input:  1,
+					output: 2,
+				},
+			},
+			expected: &TokenUsage{
+				input:  1,
+				output: 2,
+			},
+		},
+		"multiple additions": {
+			initial: &TokenUsage{},
+			toAdd: []*TokenUsage{
+				{
+					input:  1,
+					output: 2,
+				},
+				{
+					input:  1,
+					output: 2,
+				},
+			},
+			expected: &TokenUsage{
+				input:  2,
+				output: 4,
+			},
+		},
+		"multiple additions not empty": {
+			initial: &TokenUsage{
+				input:  1,
+				output: 2,
+			},
+			toAdd: []*TokenUsage{
+				{
+					input:  1,
+					output: 2,
+				},
+			},
+			expected: &TokenUsage{
+				input:  2,
+				output: 4,
+			},
+		},
+		"nil addition": {
+			initial: &TokenUsage{input: 100, output: 50},
+			toAdd:   []*TokenUsage{nil},
+			expected: &TokenUsage{
+				input:  100,
+				output: 50,
+			},
+		},
+	}
+
+	for tcName, tc := range testCases {
+		t.Run(tcName, func(t *testing.T) {
+			agg := tc.initial
+			for _, usage := range tc.toAdd {
+				agg.Add(usage)
+			}
+
+			assert.Equal(t, tc.expected, agg)
+		})
+	}
+}
+
+func TestTokenUsage_EdgeCase_AddSelf(t *testing.T) {
+	tu := &TokenUsage{
+		input:  1,
+		output: 2,
+	}
+
+	tu.Add(tu)
+
+	assert.Equal(t, 2, tu.GetInput())
+	assert.Equal(t, 4, tu.GetOutput())
+}
+
+func TestFromOpenAIUsage(t *testing.T) {
+	testCases := map[string]struct {
+		input    openai.CompletionUsage
+		expected *TokenUsage
+	}{
+		"basic conversion": {
+			input: openai.CompletionUsage{
+				PromptTokens:     100,
+				CompletionTokens: 50,
+				TotalTokens:      150,
+			},
+			expected: &TokenUsage{
+				input:  100,
+				output: 50,
+			},
+		},
+		"zero values": {
+			input: openai.CompletionUsage{
+				PromptTokens:     0,
+				CompletionTokens: 0,
+				TotalTokens:      0,
+			},
+			expected: &TokenUsage{
+				input:  0,
+				output: 0,
+			},
+		},
+	}
+
+	for tcName, tc := range testCases {
+		t.Run(tcName, func(t *testing.T) {
+			result := FromOpenAIUsage(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
**Add Token Usage Tracking**

Implements token usage tracking for OpenAI API calls during evaluation runs.

This PR adds:
- track input and output tokens separately (different pricing models)
- thread-safe token aggregation (in case we support parallel task execution)
- usage statistics in JSON results and displayed with `view` and `summary` commands

**NOTE:** This PR adds tracking of token usage only for `builtin.openai-agent`.

**Implementation Details**

New Package: `pkg/usage`
- `TokenUsage` type with `input`, and `output` fields
- Thread-safe `Add` and getter methods using mutex
- `FromOpenAIUsage()` converter for OpenAI API responses

Example output `summary`:
```
Agent used tokens:
  Input:  4559 tokens
  Output: 1215 tokens
Judge used tokens:
  Input:  1522 tokens
  Output: 668 tokens
```

with another agent
```
Estimated Tokens: ~320 (estimate - excludes system prompt & cache)
Judge used tokens:
  Input:  2438 tokens
  Output: 389 tokens
```

Example output `view`:
```
  Agent Tokens: 3039 (in=2213, out=826)
  Judge Tokens: 1138 (in=766, out=372)
```

with another agent
```
  Estimated Tokens: ~320 (in=~159, out=~161) [excludes system prompt & cache]
    input: prompt=~3, tool_results=~156
    output: message=~160, tool_calls=~1
  Judge Tokens: 2827 (in=2438, out=389)
```

**Testing**

- [x] added unit tests for `TokenUsage`
- [x] manually tested on already existing evaluation tasks
- [x] compared results of used tokens with data available in OpenAI dashboard
- [x] test that `builtin.claude-code` still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced token usage tracking: now displays actual input and output token consumption for both AI agents and LLM judges, with per-task and aggregate metrics in evaluation summaries.

* **Refactor**
  * Internal code improvements and import reorganization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->