### PR TITLE
fix: acp client does not panic on close when cmd is invalid

### DIFF
--- a/pkg/acpclient/client.go
+++ b/pkg/acpclient/client.go
@@ -197,7 +197,7 @@ func (c *client) startSubprocess(ctx context.Context) (io.Writer, io.Reader, err
 }
 
 func (c *client) closeSubprocess(ctx context.Context) error {
-	if c.cmd == nil || (c.cmd.ProcessState != nil && c.cmd.ProcessState.Exited()) {
+	if c.cmd == nil || c.cmd.Process == nil || (c.cmd.ProcessState != nil && c.cmd.ProcessState.Exited()) {
 		return nil
 	}
 


### PR DESCRIPTION
When running an ACP agent, if the cmd is missing or invalid from the ACP config, the runner panics when it calls the `Close()` method
