### PR TITLE
Add `mcpchecker version` command that displays version and commit info.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,6 +21,8 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
+      - -X github.com/mcpchecker/mcpchecker/pkg/cli.Version=v{{.Version}}
+      - -X github.com/mcpchecker/mcpchecker/pkg/cli.Commit={{.ShortCommit}}
 
   - id: agent
     main: ./cmd/agent

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ AGENT_BINARY_NAME = agent
 MCPCHECKER_BINARY_NAME = mcpchecker
 MOCK_AGENT_BINARY_NAME = functional/mock-agent
 
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "development")
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "")
+LDFLAGS = -X github.com/mcpchecker/mcpchecker/pkg/cli.Version=$(VERSION) -X github.com/mcpchecker/mcpchecker/pkg/cli.Commit=$(COMMIT)
+
 .PHONY: clean
 clean:
 	rm -f $(AGENT_BINARY_NAME) $(MCPCHECKER_BINARY_NAME) $(MOCK_AGENT_BINARY_NAME)
@@ -13,7 +17,7 @@ build-agent: clean
 
 .PHONY: build-mcpchecker
 build-mcpchecker: clean
-	go build -o $(MCPCHECKER_BINARY_NAME) ./cmd/mcpchecker/
+	go build -ldflags "$(LDFLAGS)" -o $(MCPCHECKER_BINARY_NAME) ./cmd/mcpchecker/
 
 .PHONY: build
 build: build-agent build-mcpchecker

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -19,6 +19,7 @@ It runs agents through defined tasks and validates their behavior using assertio
 	rootCmd.AddCommand(NewVerifyCmd())
 	rootCmd.AddCommand(NewSummaryCmd())
 	rootCmd.AddCommand(NewDiffCmd())
+	rootCmd.AddCommand(NewVersionCmd())
 
 	return rootCmd
 }

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/spf13/cobra"
+)
+
+// Set via ldflags at build time:
+// go build -ldflags "-X github.com/mcpchecker/mcpchecker/pkg/cli.Version=v1.0.0 -X github.com/mcpchecker/mcpchecker/pkg/cli.Commit=$(git rev-parse --short HEAD)"
+var (
+	Version = "development"
+	Commit  = ""
+)
+
+var semverRegex = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+
+func NewVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print version information",
+		Run: func(cmd *cobra.Command, args []string) {
+			// Show commit for dev builds, but not for clean releases (vX.Y.Z)
+			if Commit != "" && !semverRegex.MatchString(Version) {
+				fmt.Printf("mcpchecker version %s@%s\n", Version, Commit)
+			} else {
+				fmt.Printf("mcpchecker version %s\n", Version)
+			}
+		},
+	}
+}


### PR DESCRIPTION
Fixes: #187 

- Version info is injected at build time via ldflags in both Makefile and goreleaser. 
- Dev builds show commit hash, releases show clean version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a version command that displays the application version and commit information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->