### PR TITLE
cleanup(agent): mark openai agent as deprecated

### DIFF
--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -301,6 +301,12 @@ func NewRunnerForSpec(spec *AgentSpec) (Runner, error) {
 
 	// Check if this is an OpenAI agent with builtin configuration
 	if spec.Builtin != nil && spec.Builtin.Type == "openai-agent" {
+		fmt.Fprintf(os.Stderr, "\nWARNING: The \"openai-agent\" agent type is deprecated and will be removed in the next release.\n"+
+			"  Migrate to \"openai-acp\" by changing the agent type in your config:\n"+
+			"    - In eval config: type: \"builtin.openai-acp\"\n"+
+			"    - In agent YAML: type: \"openai-acp\"\n"+
+			"  Both types use the same MODEL_BASE_URL and MODEL_KEY environment variables.\n"+
+			"  The \"openai-acp\" agent also provides token estimation and structured tool call tracking.\n\n")
 		return NewOpenAIAgentRunner(spec.Builtin.Model, spec.Builtin.BaseURL, spec.Builtin.APIKey)
 	}
 


### PR DESCRIPTION
Going forwards, I want to try to consolidate on the ACP agent path as much as possible, as it gives us way more info

Since not all agents have ACP adapters yet, we won't remove the shell execution of agents currently. 

However, for the "builtin" agent we provide, I want to mark the non-acp way of running this as deprecated, and remove that code in the next release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deprecated OpenAI agent configuration type. Users are now guided to migrate to "openai-acp", which adds token estimation and structured tool call tracking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->