### PR TITLE
feat: Allow use of OS environment vars on extensions specific Config and Environment values

### DIFF
--- a/docs/reference/task-format.md
+++ b/docs/reference/task-format.md
@@ -223,6 +223,17 @@ The `package` field can be:
 - A GitHub package reference (e.g., `https://github.com/org/repo@v1.0.0`)
 - A relative or absolute path to a local binary (for development)
 
+An entry in the `config` and `env` fields can also reference to environment variables:
+
+```yaml
+    kubernetes:
+      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.1
+      config:
+        kubeconfig: "{env.KUBECONFIG}"
+      env:
+        KUBECONFIG: "{env.KUBECONFIG}"
+```
+
 ### Using Extension Operations
 
 Extension operations use the syntax `extension.operation`:

--- a/pkg/extension/client/manager.go
+++ b/pkg/extension/client/manager.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/genmcp/gen-mcp/pkg/template"
 	"github.com/mcpchecker/mcpchecker/pkg/extension"
 	"github.com/mcpchecker/mcpchecker/pkg/extension/protocol"
 	"github.com/mcpchecker/mcpchecker/pkg/extension/resolver"
@@ -81,9 +82,9 @@ func (m *extensionManager) Get(ctx context.Context, alias string) (Client, error
 		return nil, err
 	}
 
-	env := os.Environ()
-	for k, v := range spec.Env {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	env, err := expandEnv(spec.Env)
+	if err != nil {
+		return nil, err
 	}
 
 	c := New(Options{
@@ -96,8 +97,13 @@ func (m *extensionManager) Get(ctx context.Context, alias string) (Client, error
 		Env: env,
 	})
 
+	expandedConfig, err := expandConfig(spec.Config)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := c.Start(ctx, &protocol.InitializeParams{
-		Config: spec.Config,
+		Config: expandedConfig,
 	}); err != nil {
 		return nil, err
 	}
@@ -139,4 +145,105 @@ func ManagerToContext(ctx context.Context, manager ExtensionManager) context.Con
 func ManagerFromContext(ctx context.Context) (ExtensionManager, bool) {
 	manager, ok := ctx.Value(managerKey{}).(ExtensionManager)
 	return manager, ok
+}
+
+// expandEnv resolves template references in the given env map and returns
+// the result merged with the current OS environment as KEY=VALUE pairs.
+func expandEnv(envMap map[string]string) ([]string, error) {
+	env := os.Environ()
+	for k, v := range envMap {
+		result, err := expandTemplate(v)
+		if err != nil {
+			return nil, err
+		}
+		str, ok := result.(string)
+		if !ok {
+			return nil, fmt.Errorf("env template resolved to non-string type: %T", result)
+		}
+		env = append(env, fmt.Sprintf("%s=%s", k, str))
+	}
+	return env, nil
+}
+
+// expandConfig returns a deep copy of config with all string values resolved
+// through template expansion, iterating nested maps and slices.
+func expandConfig(config map[string]any) (map[string]any, error) {
+	if config == nil {
+		return nil, nil
+	}
+
+	expanded := make(map[string]any, len(config))
+	for k, v := range config {
+		expanded[k] = v
+	}
+
+	stack := []any{expanded}
+	for len(stack) > 0 {
+		current := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		switch c := current.(type) {
+		case map[string]any:
+			for k, v := range c {
+				switch t := v.(type) {
+				case string:
+					result, err := expandTemplate(t)
+					if err != nil {
+						return nil, err
+					}
+					c[k] = result
+				case map[string]any:
+					clone := make(map[string]any, len(t))
+					for ck, cv := range t {
+						clone[ck] = cv
+					}
+					c[k] = clone
+					stack = append(stack, clone)
+				case []any:
+					clone := make([]any, len(t))
+					copy(clone, t)
+					c[k] = clone
+					stack = append(stack, clone)
+				}
+			}
+		case []any:
+			for i, v := range c {
+				switch t := v.(type) {
+				case string:
+					result, err := expandTemplate(t)
+					if err != nil {
+						return nil, err
+					}
+					c[i] = result
+				case map[string]any:
+					clone := make(map[string]any, len(t))
+					for ck, cv := range t {
+						clone[ck] = cv
+					}
+					c[i] = clone
+					stack = append(stack, clone)
+				case []any:
+					clone := make([]any, len(t))
+					copy(clone, t)
+					c[i] = clone
+					stack = append(stack, clone)
+				}
+			}
+		}
+	}
+
+	return expanded, nil
+}
+
+// expandTemplate parses and resolves a template string, returning the expanded value.
+func expandTemplate(s string) (any, error) {
+	parsed, err := template.ParseTemplate(s, template.TemplateParserOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template: %w", err)
+	}
+	builder, err := template.NewTemplateBuilder(parsed, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create template builder: %w", err)
+	}
+	return builder.GetResult()
 }

--- a/pkg/extension/client/manager_test.go
+++ b/pkg/extension/client/manager_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/mcpchecker/mcpchecker/pkg/extension"
@@ -244,4 +245,161 @@ func TestManagerContext(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExpandEnv(t *testing.T) {
+	t.Setenv("KEY1", "value1")
+	t.Setenv("KEY2", "value2")
+
+	tt := map[string]struct {
+		envMap    map[string]string
+		wantPairs []string
+		wantErr   bool
+	}{
+		"nil map returns os environ only": {
+			envMap:    nil,
+			wantPairs: nil,
+		},
+		"plain values": {
+			envMap:    map[string]string{"KEY1": "val1", "KEY2": "val2"},
+			wantPairs: []string{"KEY1=val1", "KEY2=val2"},
+		},
+		"template references": {
+			envMap:    map[string]string{"MY_KEY1": "${KEY1}", "MY_KEY2": "{env.KEY2}"},
+			wantPairs: []string{"MY_KEY1=value1", "MY_KEY2=value2"},
+		},
+		"mixed plain and template": {
+			envMap:    map[string]string{"A": "plain", "B": "prefix-{env.KEY1}"},
+			wantPairs: []string{"A=plain", "B=prefix-value1"},
+		},
+	}
+
+	for tn, tc := range tt {
+		t.Run(tn, func(t *testing.T) {
+			result, err := expandEnv(tc.envMap)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Result should contain the OS environ
+			assert.True(t, len(result) >= len(os.Environ()))
+
+			for _, pair := range tc.wantPairs {
+				assert.True(t, containsEntry(result, pair),
+					"expected %q in result", pair)
+			}
+		})
+	}
+}
+
+func TestExpandConfig(t *testing.T) {
+	t.Setenv("EXPAND_CFG_TEST", "cfg-value")
+
+	tt := map[string]struct {
+		config  map[string]any
+		want    map[string]any
+		wantErr bool
+	}{
+		"nil config": {
+			config: nil,
+			want:   nil,
+		},
+		"plain strings unchanged": {
+			config: map[string]any{"key": "hello"},
+			want:   map[string]any{"key": "hello"},
+		},
+		"non-string values unchanged": {
+			config: map[string]any{"count": 42, "enabled": true},
+			want:   map[string]any{"count": 42, "enabled": true},
+		},
+		"template in top-level string": {
+			config: map[string]any{"path": "${EXPAND_CFG_TEST}", "path2": "{env.EXPAND_CFG_TEST}"},
+			want:   map[string]any{"path": "cfg-value", "path2": "cfg-value"},
+		},
+		"nested map with template": {
+			config: map[string]any{
+				"outer": map[string]any{
+					"inner":     "${EXPAND_CFG_TEST}",
+					"plain":     "keep",
+					"nonstring": 123,
+				},
+			},
+			want: map[string]any{
+				"outer": map[string]any{
+					"inner":     "cfg-value",
+					"plain":     "keep",
+					"nonstring": 123,
+				},
+			},
+		},
+		"slice with template strings": {
+			config: map[string]any{
+				"items": []any{"{env.EXPAND_CFG_TEST}", "static"},
+			},
+			want: map[string]any{
+				"items": []any{"cfg-value", "static"},
+			},
+		},
+		"deeply nested mixed structure": {
+			config: map[string]any{
+				"level1": map[string]any{
+					"level2": []any{
+						map[string]any{"val": "{env.EXPAND_CFG_TEST}"},
+						"literal",
+					},
+				},
+			},
+			want: map[string]any{
+				"level1": map[string]any{
+					"level2": []any{
+						map[string]any{"val": "cfg-value"},
+						"literal",
+					},
+				},
+			},
+		},
+	}
+
+	for tn, tc := range tt {
+		t.Run(tn, func(t *testing.T) {
+			result, err := expandConfig(tc.config)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, result)
+		})
+	}
+}
+
+func TestExpandConfig_DoesNotMutateOriginal(t *testing.T) {
+	t.Setenv("EXPAND_MUTATE_TEST", "replaced")
+
+	original := map[string]any{
+		"key": "${EXPAND_MUTATE_TEST}",
+		"nested": map[string]any{
+			"inner": "${EXPAND_MUTATE_TEST}",
+		},
+	}
+
+	result, err := expandConfig(original)
+	require.NoError(t, err)
+
+	assert.Equal(t, "replaced", result["key"])
+	assert.Equal(t, "${EXPAND_MUTATE_TEST}", original["key"], "original top-level value should not be modified")
+
+	origNested := original["nested"].(map[string]any)
+	assert.Equal(t, "${EXPAND_MUTATE_TEST}", origNested["inner"], "original nested value should not be modified")
+}
+
+func containsEntry(env []string, entry string) bool {
+	for _, e := range env {
+		if e == entry {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This change will allow users to use of OS environment vars on the value side of Extension specific Config and Environment values (not just constants), in the eval.yaml file.

Example:
```
  extensions:
    kubernetes:
      package: https://github.com/mcpchecker/kubernetes-extension@v0.0.1
      config:
        kubeconfig: "$KUBECONFIG"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extension env and config entries are now evaluated (templates/env vars) before the client starts; unresolved or invalid template results now halt initialization.
  * Only string-valued config entries are expanded; non-string entries are preserved as-is.

* **Documentation**
  * Added example and notes showing environment-variable interpolation for extension config entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->