### PR TITLE
feat(llmagent): support using google as provider as well as gemini

### DIFF
--- a/pkg/llmagent/provider.go
+++ b/pkg/llmagent/provider.go
@@ -15,11 +15,14 @@ const (
 	anthropicProviderKey = "anthropic"
 	openaiProviderKey    = "openai"
 	geminiProviderKey    = "gemini"
+	googleProviderKey    = "google"
 
 	anthropicUseVertexEnvVar  = "ANTHROPIC_USE_VERTEX"
 	anthropicApiKeyEnvVar     = "ANTHROPIC_API_KEY"
 	geminiUseVertexEnvVar     = "GEMINI_USE_VERTEX"
+	googleUseVertexEnvVar     = "GOOGLE_USE_VERTEX"
 	geminiApiKeyEnvVar        = "GEMINI_API_KEY"
+	googleApiKeyEnvVar        = "GOOGLE_API_KEY"
 	googleCloudProjectEnvVar  = "GOOGLE_CLOUD_PROJECT"
 	googleCloudLocationEnvVar = "GOOGLE_CLOUD_LOCATION"
 	openaiApiKeyEnvVar        = "OPENAI_API_KEY"
@@ -48,7 +51,8 @@ type providerBuilder interface {
 
 var providerBuilders = map[string]providerBuilder{
 	anthropicProviderKey: &anthropicProviderBuilder{},
-	geminiProviderKey:    &geminiProviderBuilder{},
+	geminiProviderKey:    &googleProviderBuilder{providerName: geminiProviderKey},
+	googleProviderKey:    &googleProviderBuilder{providerName: googleProviderKey},
 	openaiProviderKey:    &openaiProviderBuilder{},
 }
 
@@ -92,26 +96,32 @@ func (p *anthropicProviderBuilder) Build() (fantasy.Provider, error) {
 	return anthropic.New(opts...)
 }
 
-type geminiProviderBuilder struct{}
+type googleProviderBuilder struct {
+	providerName string
+}
 
-func (p *geminiProviderBuilder) Build() (fantasy.Provider, error) {
+func (p *googleProviderBuilder) Build() (fantasy.Provider, error) {
 	opts := []google.Option{}
 
-	useVertex := os.Getenv(geminiUseVertexEnvVar)
-	if useVertex == "1" {
+	useVertex := os.Getenv(geminiUseVertexEnvVar) == "1" || os.Getenv(googleUseVertexEnvVar) == "1"
+	if useVertex {
 		project := os.Getenv(googleCloudProjectEnvVar)
 		if project == "" {
 			return nil, fmt.Errorf(
-				"provider gemini requires env var %q to be set when %q is set to 1",
+				"provider %s requires env var %q to be set when %q or %q is set to 1",
+				p.providerName,
 				googleCloudProjectEnvVar,
+				googleUseVertexEnvVar,
 				geminiUseVertexEnvVar,
 			)
 		}
 		location := os.Getenv(googleCloudLocationEnvVar)
 		if location == "" {
 			return nil, fmt.Errorf(
-				"provider gemini requires env var %q to be set when %q is set to 1",
+				"provider %s requires env var %q to be set when %q or %q is set to 1",
+				p.providerName,
 				googleCloudLocationEnvVar,
+				googleUseVertexEnvVar,
 				geminiUseVertexEnvVar,
 			)
 		}
@@ -120,9 +130,16 @@ func (p *geminiProviderBuilder) Build() (fantasy.Provider, error) {
 	} else {
 		key := os.Getenv(geminiApiKeyEnvVar)
 		if key == "" {
+			key = os.Getenv(googleApiKeyEnvVar)
+		}
+
+		if key == "" {
 			return nil, fmt.Errorf(
-				"provider gemini requires env var %q to be set (or enable Vertex AI with %q=1)",
+				"provider %s requires env var %q or %q to be set (or enable Vertex AI with %q=1 or %q=1)",
+				p.providerName,
+				googleApiKeyEnvVar,
 				geminiApiKeyEnvVar,
+				googleUseVertexEnvVar,
 				geminiUseVertexEnvVar,
 			)
 		}

--- a/pkg/llmagent/provider_test.go
+++ b/pkg/llmagent/provider_test.go
@@ -24,6 +24,11 @@ func TestResolveProvider(t *testing.T) {
 			expectErr:   true,
 			errContains: "anthropic",
 		},
+		"error lists google as supported provider": {
+			provider:    "unknown",
+			expectErr:   true,
+			errContains: "google",
+		},
 		"empty provider name": {
 			provider:    "",
 			expectErr:   true,
@@ -53,6 +58,8 @@ func clearProviderEnv() {
 		anthropicUseVertexEnvVar,
 		geminiApiKeyEnvVar,
 		geminiUseVertexEnvVar,
+		googleApiKeyEnvVar,
+		googleUseVertexEnvVar,
 		googleCloudProjectEnvVar,
 		googleCloudLocationEnvVar,
 		openaiApiKeyEnvVar,
@@ -132,7 +139,7 @@ func TestAnthropicProviderBuilder(t *testing.T) {
 	}
 }
 
-func TestGeminiProviderBuilder(t *testing.T) {
+func TestGoogleProviderBuilder(t *testing.T) {
 	tests := map[string]struct {
 		setupEnv    func()
 		expectErr   bool
@@ -171,6 +178,47 @@ func TestGeminiProviderBuilder(t *testing.T) {
 				os.Setenv(geminiApiKeyEnvVar, "test-gemini-key")
 			},
 		},
+		"GOOGLE_API_KEY used as fallback": {
+			setupEnv: func() {
+				os.Setenv(googleApiKeyEnvVar, "test-google-key")
+			},
+		},
+		"GEMINI_API_KEY takes precedence over GOOGLE_API_KEY": {
+			setupEnv: func() {
+				os.Setenv(geminiApiKeyEnvVar, "test-gemini-key")
+				os.Setenv(googleApiKeyEnvVar, "test-google-key")
+			},
+		},
+		"GOOGLE_USE_VERTEX enables vertex": {
+			setupEnv: func() {
+				os.Setenv(googleUseVertexEnvVar, "1")
+				os.Setenv(googleCloudProjectEnvVar, "my-project")
+				os.Setenv(googleCloudLocationEnvVar, "us-central1")
+			},
+		},
+		"GOOGLE_USE_VERTEX missing project": {
+			setupEnv: func() {
+				os.Setenv(googleUseVertexEnvVar, "1")
+				os.Setenv(googleCloudLocationEnvVar, "us-central1")
+			},
+			expectErr:   true,
+			errContains: googleCloudProjectEnvVar,
+		},
+		"GOOGLE_USE_VERTEX missing location": {
+			setupEnv: func() {
+				os.Setenv(googleUseVertexEnvVar, "1")
+				os.Setenv(googleCloudProjectEnvVar, "my-project")
+			},
+			expectErr:   true,
+			errContains: googleCloudLocationEnvVar,
+		},
+		"GOOGLE_USE_VERTEX disabled treats as API key mode": {
+			setupEnv: func() {
+				os.Setenv(googleUseVertexEnvVar, "0")
+			},
+			expectErr:   true,
+			errContains: googleApiKeyEnvVar,
+		},
 	}
 
 	for name, tc := range tests {
@@ -179,7 +227,7 @@ func TestGeminiProviderBuilder(t *testing.T) {
 			defer clearProviderEnv()
 			tc.setupEnv()
 
-			builder := &geminiProviderBuilder{}
+			builder := &googleProviderBuilder{providerName: googleProviderKey}
 			provider, err := builder.Build()
 
 			if tc.expectErr {


### PR DESCRIPTION
Currently models are configured mostly through COMPANY_NAME:model_name and COMPANY_NAME_ENV_VAR, however for google models those were using gemini:model_name and GEMINI_ENV_VAR. This PR makes the config more intuitive by also supporting using google as the provider/in the env vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "google" provider option and unified Vertex support so either GEMINI_USE_VERTEX or GOOGLE_USE_VERTEX enables Vertex mode.
  * Authentication now supports GEMINI_API_KEY with automatic fallback to GOOGLE_API_KEY.

* **Bug Fixes**
  * Improved error messages to list supported providers consistently.

* **Tests**
  * Expanded tests to cover Google fallback, Vertex enablement/validation, and environment cleanup between tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->