### PR TITLE
docs(cli): add --mcp-config-file flag to check command reference

### DIFF
--- a/docs/reference/cli/mcpchecker_check.md
+++ b/docs/reference/cli/mcpchecker_check.md
@@ -13,13 +13,14 @@ mcpchecker check [eval-config-file] [flags]
 ### Options
 
 ```
-  -h, --help                    help for check
-  -l, --label-selector string   Filter taskSets by label (format: key=value, e.g., suite=kubernetes)
-  -o, --output string           Output format (text, json) (default "text")
-  -p, --parallel int            Number of parallel workers for tasks marked as parallel (1 = sequential) (default 1)
-  -r, --run string              Regular expression to match task names to run (unanchored, like go test -run)
-  -n, --runs int                Number of times to run each task (for consistency testing) (default 1)
-  -v, --verbose                 Verbose output
+  -h, --help                     help for check
+  -l, --label-selector string    Filter taskSets by label (format: key=value, e.g., suite=kubernetes)
+      --mcp-config-file string   Path to MCP config file (overrides value in eval config)
+  -o, --output string            Output format (text, json) (default "text")
+  -p, --parallel int             Number of parallel workers for tasks marked as parallel (1 = sequential) (default 1)
+  -r, --run string               Regular expression to match task names to run (unanchored, like go test -run)
+  -n, --runs int                 Number of times to run each task (for consistency testing) (default 1)
+  -v, --verbose                  Verbose output
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
run make docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced `mcpchecker check` CLI documentation formatting and alignment for improved readability.
  * Added new `--mcp-config-file` option, enabling users to specify a custom MCP configuration file path that overrides the value from the evaluation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->