### PR TITLE
fix(acp): correctly extract agent output

### DIFF
--- a/pkg/agent/acp_result.go
+++ b/pkg/agent/acp_result.go
@@ -1,8 +1,6 @@
 package agent
 
 import (
-	"encoding/json"
-
 	"github.com/coder/acp-go-sdk"
 	"github.com/mcpchecker/mcpchecker/pkg/tokens"
 )
@@ -16,25 +14,11 @@ type acpResult struct {
 
 var _ AgentResult = &acpResult{}
 
-func (res *acpResult) GetOutput() string {
-	if len(res.updates) == 0 {
-		return "got no output from acp agent"
-	}
-
-	out, err := json.Marshal(res.updates)
-	if err != nil {
-		lastUpdate := res.updates[len(res.updates)-1]
-		if lastUpdate.AgentMessageChunk != nil &&
-			lastUpdate.AgentMessageChunk.Content.Text != nil {
-			return lastUpdate.AgentMessageChunk.Content.Text.Text
-		}
-		return "unable to get agent output from last acp update"
-	}
-
-	return string(out)
+func (res *acpResult) GetOutput() []OutputStep {
+	return ExtractOutputSteps(res.updates)
 }
 
-func (res *acpResult) GetFinalMessage() string {
+func (res *acpResult) getFinalMessage() string {
 	return ExtractFinalMessage(res.updates)
 }
 
@@ -42,7 +26,7 @@ func (res *acpResult) GetToolCalls() []ToolCallSummary {
 	return ExtractToolCalls(res.updates)
 }
 
-func (res *acpResult) GetThinking() string {
+func (res *acpResult) getThinking() string {
 	return ExtractThinking(res.updates)
 }
 
@@ -53,8 +37,8 @@ func (res *acpResult) GetRawUpdates() any {
 func (res *acpResult) GetTokenEstimate() tokens.Estimate {
 	estimate := tokens.ComputeEstimate(
 		res.prompt,
-		res.GetFinalMessage(),
-		res.GetThinking(),
+		res.getFinalMessage(),
+		res.getThinking(),
 		toolCallSummaryToToolCallData(res.GetToolCalls()),
 	)
 	estimate.Source = tokens.SourceEstimated

--- a/pkg/agent/acp_runner_test.go
+++ b/pkg/agent/acp_runner_test.go
@@ -89,30 +89,33 @@ func TestAcpRunner_WithMcpServerInfo(t *testing.T) {
 
 func TestAcpRunnerResult_GetOutput(t *testing.T) {
 	tt := map[string]struct {
-		updates       []acp.SessionUpdate
-		checkContains string
-		checkEmpty    bool
+		updates  []acp.SessionUpdate
+		expected []OutputStep
 	}{
-		"empty updates returns no output message": {
-			updates:       []acp.SessionUpdate{},
-			checkContains: "got no output from acp agent",
+		"empty updates returns empty slice": {
+			updates:  []acp.SessionUpdate{},
+			expected: nil,
 		},
-		"nil updates returns no output message": {
-			updates:       nil,
-			checkContains: "got no output from acp agent",
+		"nil updates returns empty slice": {
+			updates:  nil,
+			expected: nil,
 		},
-		"valid updates marshal to JSON": {
+		"single message update returns message step": {
 			updates: []acp.SessionUpdate{
 				acp.UpdateAgentMessageText("Hello world"),
 			},
-			checkContains: "Hello world",
+			expected: []OutputStep{
+				{Type: "message", Content: "Hello world"},
+			},
 		},
-		"multiple updates marshal to JSON array": {
+		"consecutive message updates are consolidated": {
 			updates: []acp.SessionUpdate{
 				acp.UpdateAgentMessageText("First"),
 				acp.UpdateAgentMessageText("Second"),
 			},
-			checkContains: "Second",
+			expected: []OutputStep{
+				{Type: "message", Content: "FirstSecond"},
+			},
 		},
 	}
 
@@ -123,15 +126,13 @@ func TestAcpRunnerResult_GetOutput(t *testing.T) {
 			}
 
 			output := result.GetOutput()
-			if tc.checkContains != "" {
-				assert.Contains(t, output, tc.checkContains)
-			}
+			assert.Equal(t, tc.expected, output)
 		})
 	}
 }
 
 func TestAcpRunnerResult_GetOutput_WithAgentMessageChunk(t *testing.T) {
-	// Test that updates with AgentMessageChunk marshal correctly
+	// Test that updates with AgentMessageChunk return a message OutputStep
 	result := &acpResult{
 		updates: []acp.SessionUpdate{
 			acp.UpdateAgentMessageText("Final message"),
@@ -139,9 +140,10 @@ func TestAcpRunnerResult_GetOutput_WithAgentMessageChunk(t *testing.T) {
 	}
 
 	output := result.GetOutput()
-	assert.Contains(t, output, "Final message")
-	// Should be valid JSON
-	assert.True(t, len(output) > 0)
+	expected := []OutputStep{
+		{Type: "message", Content: "Final message"},
+	}
+	assert.Equal(t, expected, output)
 }
 
 // mockServer implements mcpproxy.Server for testing

--- a/pkg/agent/extract_test.go
+++ b/pkg/agent/extract_test.go
@@ -371,12 +371,12 @@ func TestFinalMessageFromSteps(t *testing.T) {
 			},
 			expected: "hello",
 		},
-		"multiple message steps concatenated": {
+		"multiple message steps returns last": {
 			steps: []agent.OutputStep{
 				{Type: "message", Content: "hello "},
 				{Type: "message", Content: "world"},
 			},
-			expected: "hello world",
+			expected: "world",
 		},
 		"ignores non-message steps": {
 			steps: []agent.OutputStep{
@@ -386,7 +386,7 @@ func TestFinalMessageFromSteps(t *testing.T) {
 			},
 			expected: "result",
 		},
-		"mixed steps extracts only messages": {
+		"mixed steps returns last message": {
 			steps: []agent.OutputStep{
 				{Type: "thinking", Content: "let me think"},
 				{Type: "tool_call", ToolCall: &agent.ToolCallSummary{Title: "Read"}},
@@ -394,7 +394,7 @@ func TestFinalMessageFromSteps(t *testing.T) {
 				{Type: "tool_call", ToolCall: &agent.ToolCallSummary{Title: "Write"}},
 				{Type: "message", Content: "second"},
 			},
-			expected: "first second",
+			expected: "second",
 		},
 	}
 

--- a/pkg/agent/extract_test.go
+++ b/pkg/agent/extract_test.go
@@ -231,3 +231,176 @@ func TestExtractThinking(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractOutputSteps(t *testing.T) {
+	title := "Read File"
+
+	tt := map[string]struct {
+		updates  []acp.SessionUpdate
+		expected []agent.OutputStep
+	}{
+		"nil updates": {
+			updates:  nil,
+			expected: nil,
+		},
+		"empty updates": {
+			updates:  []acp.SessionUpdate{},
+			expected: nil,
+		},
+		"consecutive thinking chunks consolidated": {
+			updates: []acp.SessionUpdate{
+				acp.UpdateAgentThoughtText("Let me "),
+				acp.UpdateAgentThoughtText("think about this."),
+			},
+			expected: []agent.OutputStep{
+				{Type: "thinking", Content: "Let me think about this."},
+			},
+		},
+		"consecutive message chunks consolidated": {
+			updates: []acp.SessionUpdate{
+				acp.UpdateAgentMessageText("Hello "),
+				acp.UpdateAgentMessageText("world!"),
+			},
+			expected: []agent.OutputStep{
+				{Type: "message", Content: "Hello world!"},
+			},
+		},
+		"interleaved thinking, tool_call, message produces 3 steps": {
+			updates: []acp.SessionUpdate{
+				acp.UpdateAgentThoughtText("thinking..."),
+				{
+					ToolCall: &acp.SessionUpdateToolCall{
+						ToolCallId: "tc-1",
+						Title:      "Read File",
+						Kind:       "read",
+						Status:     "running",
+					},
+				},
+				acp.UpdateAgentMessageText("done"),
+			},
+			expected: []agent.OutputStep{
+				{Type: "thinking", Content: "thinking..."},
+				{Type: "tool_call", ToolCall: &agent.ToolCallSummary{
+					Title:  "Read File",
+					Kind:   "read",
+					Status: "running",
+				}},
+				{Type: "message", Content: "done"},
+			},
+		},
+		"tool call dedup merges ToolCallUpdate": {
+			updates: []acp.SessionUpdate{
+				{
+					ToolCall: &acp.SessionUpdateToolCall{
+						ToolCallId: "tc-1",
+						Title:      "Read File",
+						RawInput:   map[string]any{"path": "/tmp/test"},
+					},
+				},
+				{
+					ToolCallUpdate: &acp.SessionToolCallUpdate{
+						ToolCallId: "tc-1",
+						Title:      &title,
+						RawOutput:  map[string]any{"content": "hello"},
+					},
+				},
+			},
+			expected: []agent.OutputStep{
+				{Type: "tool_call", ToolCall: &agent.ToolCallSummary{
+					Title:     "Read File",
+					RawInput:  map[string]any{"path": "/tmp/test"},
+					RawOutput: map[string]any{"content": "hello"},
+				}},
+			},
+		},
+		"non-consecutive thinking produces separate steps": {
+			updates: []acp.SessionUpdate{
+				acp.UpdateAgentThoughtText("first thought"),
+				acp.UpdateAgentMessageText("message"),
+				acp.UpdateAgentThoughtText("second thought"),
+			},
+			expected: []agent.OutputStep{
+				{Type: "thinking", Content: "first thought"},
+				{Type: "message", Content: "message"},
+				{Type: "thinking", Content: "second thought"},
+			},
+		},
+		"ToolCallUpdate without prior ToolCall creates step": {
+			updates: []acp.SessionUpdate{
+				{
+					ToolCallUpdate: &acp.SessionToolCallUpdate{
+						ToolCallId: "tc-1",
+						Title:      &title,
+						RawOutput:  "result data",
+					},
+				},
+			},
+			expected: []agent.OutputStep{
+				{Type: "tool_call", ToolCall: &agent.ToolCallSummary{
+					Title:     "Read File",
+					RawOutput: "result data",
+				}},
+			},
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			result := agent.ExtractOutputSteps(tc.updates)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestFinalMessageFromSteps(t *testing.T) {
+	tt := map[string]struct {
+		steps    []agent.OutputStep
+		expected string
+	}{
+		"nil steps": {
+			steps:    nil,
+			expected: "",
+		},
+		"empty steps": {
+			steps:    []agent.OutputStep{},
+			expected: "",
+		},
+		"single message step": {
+			steps: []agent.OutputStep{
+				{Type: "message", Content: "hello"},
+			},
+			expected: "hello",
+		},
+		"multiple message steps concatenated": {
+			steps: []agent.OutputStep{
+				{Type: "message", Content: "hello "},
+				{Type: "message", Content: "world"},
+			},
+			expected: "hello world",
+		},
+		"ignores non-message steps": {
+			steps: []agent.OutputStep{
+				{Type: "thinking", Content: "thinking..."},
+				{Type: "message", Content: "result"},
+				{Type: "tool_call", ToolCall: &agent.ToolCallSummary{Title: "Read"}},
+			},
+			expected: "result",
+		},
+		"mixed steps extracts only messages": {
+			steps: []agent.OutputStep{
+				{Type: "thinking", Content: "let me think"},
+				{Type: "tool_call", ToolCall: &agent.ToolCallSummary{Title: "Read"}},
+				{Type: "message", Content: "first "},
+				{Type: "tool_call", ToolCall: &agent.ToolCallSummary{Title: "Write"}},
+				{Type: "message", Content: "second"},
+			},
+			expected: "first second",
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, agent.FinalMessageFromSteps(tc.steps))
+		})
+	}
+}

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -194,6 +194,23 @@ func ExtractOutputSteps(updates []acp.SessionUpdate) []OutputStep {
 					Type:     "tool_call",
 					ToolCall: tc,
 				})
+			} else {
+				tc := toolCallMap[id]
+				if update.ToolCall.Title != "" {
+					tc.Title = update.ToolCall.Title
+				}
+				if string(update.ToolCall.Kind) != "" {
+					tc.Kind = string(update.ToolCall.Kind)
+				}
+				if string(update.ToolCall.Status) != "" {
+					tc.Status = string(update.ToolCall.Status)
+				}
+				if update.ToolCall.RawInput != nil {
+					tc.RawInput = update.ToolCall.RawInput
+				}
+				if update.ToolCall.RawOutput != nil {
+					tc.RawOutput = update.ToolCall.RawOutput
+				}
 			}
 		}
 
@@ -232,15 +249,14 @@ func ExtractOutputSteps(updates []acp.SessionUpdate) []OutputStep {
 	return steps
 }
 
-// FinalMessageFromSteps concatenates the Content from all "message"-type OutputSteps.
+// FinalMessageFromSteps returns the content of the last "message"-type OutputStep.
 func FinalMessageFromSteps(steps []OutputStep) string {
-	var sb strings.Builder
-	for _, s := range steps {
-		if s.Type == "message" {
-			sb.WriteString(s.Content)
+	for i := len(steps) - 1; i >= 0; i-- {
+		if steps[i].Type == "message" {
+			return steps[i].Content
 		}
 	}
-	return sb.String()
+	return ""
 }
 
 // turnBuilder accumulates session update data and produces per-turn token counts.

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -35,6 +35,13 @@ type ToolCallSummary struct {
 	RawOutput any    `json:"rawOutput,omitempty"`
 }
 
+// OutputStep represents a single logical step in the agent's output.
+type OutputStep struct {
+	Type     string           `json:"type"`              // "thinking", "message", "tool_call"
+	Content  string           `json:"content,omitempty"` // text for thinking/message steps
+	ToolCall *ToolCallSummary `json:"toolCall,omitempty"`
+}
+
 // ExtractToolCalls extracts deduplicated tool call summaries from ACP session updates.
 // It merges data from both ToolCall (initial) and ToolCallUpdate (subsequent) messages.
 func ExtractToolCalls(updates []acp.SessionUpdate) []ToolCallSummary {
@@ -118,6 +125,124 @@ func ExtractThinking(updates []acp.SessionUpdate) string {
 	return thinking.String()
 }
 
+// ExtractOutputSteps processes ACP session updates into chronological OutputStep slices.
+// Consecutive thinking chunks are consolidated into a single "thinking" step,
+// consecutive message chunks into a single "message" step, and tool calls
+// (deduplicated by ID, merged with ToolCallUpdate data) become "tool_call" steps.
+// Non-consecutive runs of the same type produce separate steps.
+func ExtractOutputSteps(updates []acp.SessionUpdate) []OutputStep {
+	var steps []OutputStep
+	var currentType string
+	var buf strings.Builder
+
+	// Track tool calls for dedup/merge, same pattern as ExtractToolCalls
+	toolCallMap := make(map[acp.ToolCallId]*ToolCallSummary)
+	var toolCallOrder []acp.ToolCallId
+
+	flush := func() {
+		if currentType == "" {
+			return
+		}
+		if currentType == "thinking" || currentType == "message" {
+			if buf.Len() > 0 {
+				steps = append(steps, OutputStep{
+					Type:    currentType,
+					Content: buf.String(),
+				})
+				buf.Reset()
+			}
+		}
+		currentType = ""
+	}
+
+	for _, update := range updates {
+		isThinking := update.AgentThoughtChunk != nil && update.AgentThoughtChunk.Content.Text != nil
+		isMessage := update.AgentMessageChunk != nil && update.AgentMessageChunk.Content.Text != nil
+		isToolCall := update.ToolCall != nil
+		isToolCallUpdate := update.ToolCallUpdate != nil
+
+		if isThinking {
+			if currentType != "thinking" {
+				flush()
+				currentType = "thinking"
+			}
+			buf.WriteString(update.AgentThoughtChunk.Content.Text.Text)
+		}
+
+		if isMessage {
+			if currentType != "message" {
+				flush()
+				currentType = "message"
+			}
+			buf.WriteString(update.AgentMessageChunk.Content.Text.Text)
+		}
+
+		if isToolCall {
+			flush()
+			id := update.ToolCall.ToolCallId
+			if _, exists := toolCallMap[id]; !exists {
+				toolCallOrder = append(toolCallOrder, id)
+				tc := &ToolCallSummary{
+					Title:     update.ToolCall.Title,
+					Kind:      string(update.ToolCall.Kind),
+					Status:    string(update.ToolCall.Status),
+					RawInput:  update.ToolCall.RawInput,
+					RawOutput: update.ToolCall.RawOutput,
+				}
+				toolCallMap[id] = tc
+				steps = append(steps, OutputStep{
+					Type:     "tool_call",
+					ToolCall: tc,
+				})
+			}
+		}
+
+		if isToolCallUpdate {
+			id := update.ToolCallUpdate.ToolCallId
+			tc, exists := toolCallMap[id]
+			if !exists {
+				flush()
+				toolCallOrder = append(toolCallOrder, id)
+				tc = &ToolCallSummary{}
+				toolCallMap[id] = tc
+				steps = append(steps, OutputStep{
+					Type:     "tool_call",
+					ToolCall: tc,
+				})
+			}
+			if update.ToolCallUpdate.Title != nil {
+				tc.Title = *update.ToolCallUpdate.Title
+			}
+			if update.ToolCallUpdate.Kind != nil {
+				tc.Kind = string(*update.ToolCallUpdate.Kind)
+			}
+			if update.ToolCallUpdate.Status != nil {
+				tc.Status = string(*update.ToolCallUpdate.Status)
+			}
+			if update.ToolCallUpdate.RawInput != nil {
+				tc.RawInput = update.ToolCallUpdate.RawInput
+			}
+			if update.ToolCallUpdate.RawOutput != nil {
+				tc.RawOutput = update.ToolCallUpdate.RawOutput
+			}
+		}
+	}
+
+	flush()
+	return steps
+}
+
+// FinalMessageFromSteps concatenates the Content from all "message"-type OutputSteps.
+func FinalMessageFromSteps(steps []OutputStep) string {
+	var sb strings.Builder
+	for _, s := range steps {
+		if s.Type == "message" {
+			sb.WriteString(s.Content)
+		}
+	}
+	return sb.String()
+}
+
 // turnBuilder accumulates session update data and produces per-turn token counts.
 type turnBuilder struct {
 	tok            tokenizer.Tokenizer
@@ -189,10 +314,8 @@ func ExtractTurns(updates []acp.SessionUpdate) []tokens.TurnTokens {
 
 // AgentResult provides access to the results of an agent execution.
 type AgentResult interface {
-	GetOutput() string
-	GetFinalMessage() string
+	GetOutput() []OutputStep
 	GetToolCalls() []ToolCallSummary
-	GetThinking() string
 	GetRawUpdates() any
 	GetTokenEstimate() tokens.Estimate
 }
@@ -206,20 +329,12 @@ type agentSpecRunnerResult struct {
 	commandOutput string
 }
 
-func (a *agentSpecRunnerResult) GetOutput() string {
-	return a.commandOutput
-}
-
-func (a *agentSpecRunnerResult) GetFinalMessage() string {
-	return a.commandOutput // Shell output is the final message
+func (a *agentSpecRunnerResult) GetOutput() []OutputStep {
+	return []OutputStep{{Type: "message", Content: a.commandOutput}}
 }
 
 func (a *agentSpecRunnerResult) GetToolCalls() []ToolCallSummary {
 	return nil // Shell runner doesn't have structured tool call data
-}
-
-func (a *agentSpecRunnerResult) GetThinking() string {
-	return "" // Shell runner doesn't capture thinking
 }
 
 func (a *agentSpecRunnerResult) GetRawUpdates() any {

--- a/pkg/eval/runner.go
+++ b/pkg/eval/runner.go
@@ -623,22 +623,14 @@ func (r *evalRunner) executeTaskSteps(
 		result.TaskPassed = false
 		result.TaskError = err.Error()
 		result.AgentExecutionError = true
-		// Extract agent output from phase output for backwards compatibility
-		if agentOutput != nil && len(agentOutput.Steps) > 0 {
-			lastStep := agentOutput.Steps[len(agentOutput.Steps)-1]
-			if out, ok := lastStep.Outputs["output"]; ok {
-				result.TaskOutput = out
-			}
+		if agentOutput != nil && agentOutput.AgentDetails != nil {
+			result.TaskOutput = agent.FinalMessageFromSteps(agentOutput.AgentDetails.OutputSteps)
 		}
 		return
 	}
 
-	// Extract agent output from phase output for backwards compatibility
-	if agentOutput != nil && len(agentOutput.Steps) > 0 {
-		lastStep := agentOutput.Steps[len(agentOutput.Steps)-1]
-		if out, ok := lastStep.Outputs["output"]; ok {
-			result.TaskOutput = out
-		}
+	if agentOutput != nil && agentOutput.AgentDetails != nil {
+		result.TaskOutput = agent.FinalMessageFromSteps(agentOutput.AgentDetails.OutputSteps)
 	}
 
 	// Extract token estimate from agent details

--- a/pkg/eval/runner.go
+++ b/pkg/eval/runner.go
@@ -625,7 +625,8 @@ func (r *evalRunner) executeTaskSteps(
 		result.AgentExecutionError = true
 		// Extract agent output from phase output for backwards compatibility
 		if agentOutput != nil && len(agentOutput.Steps) > 0 {
-			if out, ok := agentOutput.Steps[0].Outputs["output"]; ok {
+			lastStep := agentOutput.Steps[len(agentOutput.Steps)-1]
+			if out, ok := lastStep.Outputs["output"]; ok {
 				result.TaskOutput = out
 			}
 		}
@@ -634,7 +635,8 @@ func (r *evalRunner) executeTaskSteps(
 
 	// Extract agent output from phase output for backwards compatibility
 	if agentOutput != nil && len(agentOutput.Steps) > 0 {
-		if out, ok := agentOutput.Steps[0].Outputs["output"]; ok {
+		lastStep := agentOutput.Steps[len(agentOutput.Steps)-1]
+		if out, ok := lastStep.Outputs["output"]; ok {
 			result.TaskOutput = out
 		}
 	}

--- a/pkg/task/run.go
+++ b/pkg/task/run.go
@@ -350,7 +350,6 @@ func (r *taskRunner) RunAgent(ctx context.Context, agentRunner agent.Runner) (*P
 				Type:    "message",
 				Success: true,
 				Message: os.Content,
-				Outputs: map[string]string{"output": os.Content},
 			})
 		case "tool_call":
 			step := &steps.StepOutput{

--- a/pkg/task/run.go
+++ b/pkg/task/run.go
@@ -18,8 +18,7 @@ import (
 type AgentDetails struct {
 	TokenEstimate *tokens.Estimate        `json:"tokenEstimate,omitempty"`
 	ToolCalls     []agent.ToolCallSummary `json:"toolCalls,omitempty"`
-	FinalMessage  string                  `json:"finalMessage,omitempty"`
-	Thinking      string                  `json:"thinking,omitempty"`
+	OutputSteps   []agent.OutputStep      `json:"outputSteps,omitempty"`
 }
 
 // PhaseOutput represents the output from a task phase (setup, agent, verify, or cleanup).
@@ -324,29 +323,51 @@ func (r *taskRunner) RunAgent(ctx context.Context, agentRunner agent.Runner) (*P
 		}, detailErr
 	}
 
-	output := result.GetOutput()
-	r.output = output
+	outputSteps := result.GetOutput()
+	finalMessage := agent.FinalMessageFromSteps(outputSteps)
+	r.output = finalMessage
 
 	// Capture structured agent details
 	tokenEstimate := result.GetTokenEstimate()
 	agentDetails := &AgentDetails{
 		TokenEstimate: &tokenEstimate,
 		ToolCalls:     result.GetToolCalls(),
-		FinalMessage:  result.GetFinalMessage(),
-		Thinking:      result.GetThinking(),
+		OutputSteps:   outputSteps,
+	}
+
+	// Convert each OutputStep to a StepOutput for the phase
+	phaseSteps := make([]*steps.StepOutput, 0, len(outputSteps))
+	for _, os := range outputSteps {
+		switch os.Type {
+		case "thinking":
+			phaseSteps = append(phaseSteps, &steps.StepOutput{
+				Type:    "thinking",
+				Success: true,
+				Message: os.Content,
+			})
+		case "message":
+			phaseSteps = append(phaseSteps, &steps.StepOutput{
+				Type:    "message",
+				Success: true,
+				Message: os.Content,
+				Outputs: map[string]string{"output": os.Content},
+			})
+		case "tool_call":
+			step := &steps.StepOutput{
+				Type:    "tool_call",
+				Success: true,
+			}
+			if os.ToolCall != nil {
+				step.Message = os.ToolCall.Title
+			}
+			phaseSteps = append(phaseSteps, step)
+		}
 	}
 
 	return &PhaseOutput{
 		Success:      true,
 		AgentDetails: agentDetails,
-		Steps: []*steps.StepOutput{{
-			Type:    "agent",
-			Success: true,
-			Message: output,
-			Outputs: map[string]string{
-				"output": output,
-			},
-		}},
+		Steps:        phaseSteps,
 	}, nil
 }
 


### PR DESCRIPTION
The original intent of the `GetOutput` method on the agent is to provide the final result from the agent.

This got confused in the context of the acp agents, and would return everything.

This causes issues with llmjudges using acp outputs, as they may confuse internal steps with the final output.

To address this issue (without losing the full output) this PR:
1. Switches to returning a slice of output steps from the agent
2. Switches the llmjudge to see the final output message from the agent (not everything)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Agent responses moved from free-form strings to structured output steps (ordered "thinking", "message", "tool_call"), improving clarity and consistency in phase outputs.
* **New Features**
  * Runners now surface structured output steps (e.g., a single message step for shell/command output).
* **Tests**
  * Added and updated tests to validate extraction, consolidation, and final-message derivation from output steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->