### PR TITLE
fix(acp): no more race condition in client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	charm.land/fantasy v0.17.1
-	github.com/coder/acp-go-sdk v0.6.3
+	github.com/coder/acp-go-sdk v0.6.4-0.20260227160919-584abe6abe22
 	github.com/fatih/color v1.19.0
 	github.com/genmcp/gen-mcp v0.2.3
 	github.com/google/jsonschema-go v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUoc7Ik9EfrFqcylYqgPZ9ANSbTAntnE=
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
-github.com/coder/acp-go-sdk v0.6.3 h1:LsXQytehdjKIYJnoVWON/nf7mqbiarnyuyE3rrjBsXQ=
-github.com/coder/acp-go-sdk v0.6.3/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
+github.com/coder/acp-go-sdk v0.6.4-0.20260227160919-584abe6abe22 h1:hwveFaJNFv5CUb+M/VviN8EKhkj2xHymIARveBr7I1U=
+github.com/coder/acp-go-sdk v0.6.4-0.20260227160919-584abe6abe22/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=
 github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/pkg/acpclient/acp.go
+++ b/pkg/acpclient/acp.go
@@ -43,7 +43,12 @@ func (c *client) RequestPermission(ctx context.Context, params acp.RequestPermis
 		}
 
 		return acp.RequestPermissionResponse{
-			Outcome: acp.NewRequestPermissionOutcomeSelected(bestOpt.OptionId),
+			Outcome: acp.RequestPermissionOutcome{
+				Selected: &acp.RequestPermissionOutcomeSelected{
+					Outcome:  "selected",
+					OptionId: bestOpt.OptionId,
+				},
+			},
 		}, nil
 	}
 
@@ -65,7 +70,12 @@ func (c *client) RequestPermission(ctx context.Context, params acp.RequestPermis
 		return acp.RequestPermissionResponse{}, fmt.Errorf("no reject option provided")
 	}
 
-	return acp.RequestPermissionResponse{Outcome: acp.NewRequestPermissionOutcomeSelected(bestOpt.OptionId)}, nil
+	return acp.RequestPermissionResponse{Outcome: acp.RequestPermissionOutcome{
+		Selected: &acp.RequestPermissionOutcomeSelected{
+			Outcome:  "selected",
+			OptionId: bestOpt.OptionId,
+		},
+	}}, nil
 }
 
 // Notification containing a session update from the agent.

--- a/pkg/acpclient/acp_test.go
+++ b/pkg/acpclient/acp_test.go
@@ -25,7 +25,7 @@ func TestClient_RequestPermission(t *testing.T) {
 			},
 			params: acp.RequestPermissionRequest{
 				SessionId: "session-1",
-				ToolCall: acp.RequestPermissionToolCall{
+				ToolCall: acp.ToolCallUpdate{
 					ToolCallId: "call-1",
 					Title:      ptr("Read File"),
 				},
@@ -42,7 +42,7 @@ func TestClient_RequestPermission(t *testing.T) {
 			},
 			params: acp.RequestPermissionRequest{
 				SessionId: "session-1",
-				ToolCall: acp.RequestPermissionToolCall{
+				ToolCall: acp.ToolCallUpdate{
 					ToolCallId: "call-1",
 					Title:      ptr("Read File"),
 				},
@@ -59,7 +59,7 @@ func TestClient_RequestPermission(t *testing.T) {
 			},
 			params: acp.RequestPermissionRequest{
 				SessionId: "session-1",
-				ToolCall: acp.RequestPermissionToolCall{
+				ToolCall: acp.ToolCallUpdate{
 					ToolCallId: "call-1",
 					Title:      ptr("Delete File"),
 				},
@@ -75,7 +75,7 @@ func TestClient_RequestPermission(t *testing.T) {
 			sessions: map[acp.SessionId]*session{},
 			params: acp.RequestPermissionRequest{
 				SessionId: "nonexistent",
-				ToolCall: acp.RequestPermissionToolCall{
+				ToolCall: acp.ToolCallUpdate{
 					ToolCallId: "call-1",
 					Title:      ptr("Read File"),
 				},
@@ -92,7 +92,7 @@ func TestClient_RequestPermission(t *testing.T) {
 			},
 			params: acp.RequestPermissionRequest{
 				SessionId: "session-1",
-				ToolCall: acp.RequestPermissionToolCall{
+				ToolCall: acp.ToolCallUpdate{
 					ToolCallId: "call-1",
 					Title:      ptr("Read File"),
 				},

--- a/pkg/acpclient/client.go
+++ b/pkg/acpclient/client.go
@@ -129,7 +129,7 @@ func (c *client) run(ctx context.Context, prompt string, servers mcpproxy.Server
 		}
 
 		mcpServers = append(mcpServers, acp.McpServer{
-			Http: &acp.McpServerHttp{
+			Http: &acp.McpServerHttpInline{
 				Name:    srv.GetName(),
 				Url:     cfg.URL,
 				Type:    mcpclient.TransportTypeHttp,

--- a/pkg/acpclient/session.go
+++ b/pkg/acpclient/session.go
@@ -24,7 +24,7 @@ func NewSession(mcpServers mcpproxy.ServerManager) *session {
 	}
 }
 
-func (s *session) recordPermissionToolCall(call acp.RequestPermissionToolCall) {
+func (s *session) recordPermissionToolCall(call acp.ToolCallUpdate) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -41,7 +41,7 @@ func (s *session) recordPermissionToolCall(call acp.RequestPermissionToolCall) {
 	})
 }
 
-func (s *session) isAllowedToolCall(ctx context.Context, call acp.RequestPermissionToolCall) bool {
+func (s *session) isAllowedToolCall(ctx context.Context, call acp.ToolCallUpdate) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/pkg/acpclient/session_test.go
+++ b/pkg/acpclient/session_test.go
@@ -43,12 +43,12 @@ func (m *mockServerManager) GetCallHistoryForServer(_ string) (mcpproxy.CallHist
 func TestSession_IsAllowedToolCall(t *testing.T) {
 	tt := map[string]struct {
 		allowedTools []*mcp.Tool
-		call         acp.RequestPermissionToolCall
+		call         acp.ToolCallUpdate
 		expected     bool
 	}{
 		"allowed when tool title matches": {
 			allowedTools: []*mcp.Tool{{Name: "read_file", Title: "Read File"}},
-			call: acp.RequestPermissionToolCall{
+			call: acp.ToolCallUpdate{
 				ToolCallId: "call-1",
 				Title:      ptr("Read File"),
 			},
@@ -56,7 +56,7 @@ func TestSession_IsAllowedToolCall(t *testing.T) {
 		},
 		"not allowed when tool title does not match": {
 			allowedTools: []*mcp.Tool{{Name: "read_file", Title: "Read File"}},
-			call: acp.RequestPermissionToolCall{
+			call: acp.ToolCallUpdate{
 				ToolCallId: "call-1",
 				Title:      ptr("Delete File"),
 			},
@@ -64,7 +64,7 @@ func TestSession_IsAllowedToolCall(t *testing.T) {
 		},
 		"not allowed when no tools configured": {
 			allowedTools: []*mcp.Tool{},
-			call: acp.RequestPermissionToolCall{
+			call: acp.ToolCallUpdate{
 				ToolCallId: "call-1",
 				Title:      ptr("Read File"),
 			},
@@ -72,7 +72,7 @@ func TestSession_IsAllowedToolCall(t *testing.T) {
 		},
 		"not allowed when title is nil and no prior update": {
 			allowedTools: []*mcp.Tool{{Name: "read_file", Title: "Read File"}},
-			call: acp.RequestPermissionToolCall{
+			call: acp.ToolCallUpdate{
 				ToolCallId: "call-1",
 				Title:      nil,
 			},
@@ -111,7 +111,7 @@ func TestSession_IsAllowedToolCall_WithPriorUpdate(t *testing.T) {
 	}
 
 	// Now check with a call that has no title - should use stored title
-	call := acp.RequestPermissionToolCall{
+	call := acp.ToolCallUpdate{
 		ToolCallId: "call-1",
 		Title:      nil,
 	}
@@ -308,7 +308,7 @@ func TestSession_IsAllowedToolCall_FuzzyMatching(t *testing.T) {
 			}
 			s := NewSession(mgr)
 
-			call := acp.RequestPermissionToolCall{
+			call := acp.ToolCallUpdate{
 				ToolCallId: "call-1",
 				Title:      ptr(tc.callTitle),
 			}

--- a/pkg/llmagent/acp_agent.go
+++ b/pkg/llmagent/acp_agent.go
@@ -165,6 +165,10 @@ func (a *acpAgent) SetSessionMode(_ context.Context, _ acp.SetSessionModeRequest
 	return acp.SetSessionModeResponse{}, nil
 }
 
+func (a *acpAgent) SetSessionConfigOption(_ context.Context, _ acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error) {
+	return acp.SetSessionConfigOptionResponse{}, nil
+}
+
 func (a *acpAgent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.PromptResponse, error) {
 	a.mu.Lock()
 	s, ok := a.sessions[params.SessionId]
@@ -297,7 +301,7 @@ func (a *acpAgent) toolInterceptorForSession(sessionId acp.SessionId) toolInterc
 
 		resp, err := a.conn.RequestPermission(ctx, acp.RequestPermissionRequest{
 			SessionId: sessionId,
-			ToolCall: acp.RequestPermissionToolCall{
+			ToolCall: acp.ToolCallUpdate{
 				ToolCallId: toolId,
 				RawInput:   rawInput,
 			},


### PR DESCRIPTION
The ACP SDK had a race condition in the client, caused by the notification handlers and the non notification handlers being synchronized differently.

Unfortunately there is no new release since Nov with all the new commits and fixes, so we have to pin to a commit on `main`. For now, I have picked the most recent commit.

This PR also includes some changes to fix breaking changes introduced in the SDK

Fixes #270 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to latest versions.
  * Refined internal permission request handling structures.
  * Updated HTTP transport configuration for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->