### PR TITLE
feat: add task timeouts

### DIFF
--- a/docs/how-to/write-tasks.md
+++ b/docs/how-to/write-tasks.md
@@ -198,6 +198,58 @@ taskSets:
 - Combine directory structure with labels for flexible organization
 - Use globs for path-based filtering, labels for semantic filtering
 
+## Task Timeouts
+
+You can set timeout limits to prevent tasks from running indefinitely. This is useful when agents get stuck in loops or when tasks interact with slow external services.
+
+### Per-task timeout
+
+Add `limits` to the task spec:
+
+```yaml
+spec:
+  limits:
+    timeout: "15m"       # Max time for setup + agent + verify
+    cleanupTimeout: "2m" # Max time for cleanup (runs even after timeout)
+
+  setup:
+    # ...
+```
+
+### Eval-level defaults
+
+Set defaults for all tasks in your eval config with `defaultTaskLimits`:
+
+```yaml
+config:
+  defaultTaskLimits:
+    timeout: "30m"
+    cleanupTimeout: "5m"
+  agent:
+    type: "builtin.claude-code"
+  taskSets:
+    - glob: tasks/**/*.yaml
+```
+
+Tasks with their own `spec.limits` override these defaults.
+
+### CLI overrides
+
+Override timeouts from the command line:
+
+```bash
+# Set a default for tasks that don't specify their own
+mcpchecker check eval.yaml --default-task-timeout 20m
+
+# Hard override ALL tasks (even those with spec.limits)
+mcpchecker check eval.yaml --task-timeout 10m
+
+# Same pattern for cleanup
+mcpchecker check eval.yaml --cleanup-timeout 5m
+```
+
+For the full precedence rules, see [Task Timeouts](../reference/task-format.md#task-timeouts) in the reference.
+
 ## Eval Config with Assertions
 
 A complete eval config ties together the agent, MCP server, and tasks:

--- a/docs/how-to/write-tasks.md
+++ b/docs/how-to/write-tasks.md
@@ -245,7 +245,8 @@ mcpchecker check eval.yaml --default-task-timeout 20m
 mcpchecker check eval.yaml --task-timeout 10m
 
 # Same pattern for cleanup
-mcpchecker check eval.yaml --cleanup-timeout 5m
+mcpchecker check eval.yaml --default-cleanup-timeout 5m
+mcpchekcer check eval.yaml --cleanup-timeout 5m
 ```
 
 For the full precedence rules, see [Task Timeouts](../reference/task-format.md#task-timeouts) in the reference.

--- a/docs/reference/cli/mcpchecker_check.md
+++ b/docs/reference/cli/mcpchecker_check.md
@@ -13,14 +13,18 @@ mcpchecker check [eval-config-file] [flags]
 ### Options
 
 ```
-  -h, --help                     help for check
-  -l, --label-selector string    Filter taskSets by label (format: key=value, e.g., suite=kubernetes)
-      --mcp-config-file string   Path to MCP config file (overrides value in eval config)
-  -o, --output string            Output format (text, json) (default "text")
-  -p, --parallel int             Number of parallel workers for tasks marked as parallel (1 = sequential) (default 1)
-  -r, --run string               Regular expression to match task names to run (unanchored, like go test -run)
-  -n, --runs int                 Number of times to run each task (for consistency testing) (default 1)
-  -v, --verbose                  Verbose output
+      --cleanup-timeout string           Hard override cleanup timeout for ALL tasks (e.g., '2m')
+      --default-cleanup-timeout string   Default cleanup timeout for tasks without their own (e.g., '2m')
+      --default-task-timeout string      Default timeout for tasks without their own (e.g., '15m', '1h')
+  -h, --help                             help for check
+  -l, --label-selector string            Filter taskSets by label (format: key=value, e.g., suite=kubernetes)
+      --mcp-config-file string           Path to MCP config file (overrides value in eval config)
+  -o, --output string                    Output format (text, json) (default "text")
+  -p, --parallel int                     Number of parallel workers for tasks marked as parallel (1 = sequential) (default 1)
+  -r, --run string                       Regular expression to match task names to run (unanchored, like go test -run)
+  -n, --runs int                         Number of times to run each task (for consistency testing) (default 1)
+      --task-timeout string              Hard override timeout for ALL tasks (e.g., '15m', '1h')
+  -v, --verbose                          Verbose output
 ```
 
 ### SEE ALSO

--- a/docs/reference/task-format.md
+++ b/docs/reference/task-format.md
@@ -33,6 +33,10 @@ spec:
   requires:           # Optional. Extension requirements.
     - extension: string
 
+  limits:             # Optional. Timeout constraints for this task.
+    timeout: string   #   Max duration for setup + agent + verify (e.g., '15m', '1h').
+    cleanupTimeout: string  #   Max duration for cleanup phase (e.g., '5m').
+
   setup:              # Optional. Steps to run before the agent.
     - stepType: { ... }
 
@@ -304,6 +308,68 @@ mcpchecker check eval.yaml
 # Override to run each task 10 times
 mcpchecker check eval.yaml --runs 10
 ```
+
+## Task Timeouts
+
+Tasks can have timeout limits to prevent indefinite execution (e.g., when an agent gets stuck in a loop).
+
+### Task-level timeout
+
+Set `spec.limits.timeout` to limit the combined duration of setup, agent, and verify phases:
+
+```yaml
+spec:
+  limits:
+    timeout: "15m"
+    cleanupTimeout: "5m"
+```
+
+- **timeout** -- Maximum time for setup + agent + verify. When exceeded, the task is cancelled and marked as failed with a timeout error.
+- **cleanupTimeout** -- Maximum time for the cleanup phase. Cleanup always runs, even after a timeout, using its own independent timeout.
+
+If neither is set, there is no timeout (backward-compatible).
+
+### Eval-level defaults
+
+Set default limits for all tasks in the eval config:
+
+```yaml
+kind: Eval
+metadata:
+  name: my-eval
+config:
+  defaultTaskLimits:
+    timeout: "30m"
+    cleanupTimeout: "5m"
+  # ...
+```
+
+Individual tasks can override these defaults via `spec.limits`.
+
+### CLI overrides
+
+The `check` command provides four timeout flags:
+
+| Flag | Effect |
+|------|--------|
+| `--default-task-timeout` | Overrides `defaultTaskLimits.timeout` for tasks that don't specify their own |
+| `--task-timeout` | Hard override -- applies to ALL tasks regardless of their `spec.limits` |
+| `--default-cleanup-timeout` | Same pattern for cleanup timeouts |
+| `--cleanup-timeout` | Hard override for ALL cleanup timeouts |
+
+### Precedence
+
+Timeouts are resolved in this order (highest priority first):
+
+1. `--task-timeout` / `--cleanup-timeout` (CLI hard override)
+2. `spec.limits.timeout` / `spec.limits.cleanupTimeout` (per-task)
+3. `--default-task-timeout` / `--default-cleanup-timeout` (CLI default override)
+4. `config.defaultTaskLimits.timeout` / `config.defaultTaskLimits.cleanupTimeout` (eval YAML)
+5. No timeout
+
+### Interaction with step-level timeouts
+
+Individual `script` and `http` steps have their own timeouts (default: 5 minutes). Step timeouts nest inside the task timeout -- if the task timeout expires, all running steps are cancelled. Step timeouts remain useful for bounding individual operations within a larger task budget.
 
 ## Complete Example
 

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -25,6 +25,10 @@ func NewEvalCmd() *cobra.Command {
 	var parallelWorkers int
 	var runs int
 	var mcpConfigFile string
+	var defaultTaskTimeout string
+	var taskTimeout string
+	var defaultCleanupTimeout string
+	var cleanupTimeout string
 
 	cmd := &cobra.Command{
 		Use:   "check [eval-config-file]",
@@ -73,6 +77,11 @@ func NewEvalCmd() *cobra.Command {
 				ParallelWorkers:   parallelWorkers,
 				Runs:              runs,
 				RunsExplicitlySet: cmd.Flags().Changed("runs"),
+
+				DefaultTaskTimeout:    defaultTaskTimeout,
+				TaskTimeout:           taskTimeout,
+				DefaultCleanupTimeout: defaultCleanupTimeout,
+				CleanupTimeout:        cleanupTimeout,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create eval runner: %w", err)
@@ -120,6 +129,10 @@ func NewEvalCmd() *cobra.Command {
 	cmd.Flags().IntVarP(&parallelWorkers, "parallel", "p", 1, "Number of parallel workers for tasks marked as parallel (1 = sequential)")
 	cmd.Flags().IntVarP(&runs, "runs", "n", 1, "Number of times to run each task (for consistency testing)")
 	cmd.Flags().StringVar(&mcpConfigFile, "mcp-config-file", "", "Path to MCP config file (overrides value in eval config)")
+	cmd.Flags().StringVar(&defaultTaskTimeout, "default-task-timeout", "", "Default timeout for tasks without their own (e.g., '15m', '1h')")
+	cmd.Flags().StringVar(&taskTimeout, "task-timeout", "", "Hard override timeout for ALL tasks (e.g., '15m', '1h')")
+	cmd.Flags().StringVar(&defaultCleanupTimeout, "default-cleanup-timeout", "", "Default cleanup timeout for tasks without their own (e.g., '2m')")
+	cmd.Flags().StringVar(&cleanupTimeout, "cleanup-timeout", "", "Hard override cleanup timeout for ALL tasks (e.g., '2m')")
 
 	return cmd
 }
@@ -197,6 +210,12 @@ func (d *progressDisplay) handleProgress(event eval.ProgressEvent) {
 	case eval.EventTaskAssertions:
 		if d.verbose {
 			fmt.Printf("%s→ Evaluating assertions...\n", prefix)
+		}
+
+	case eval.EventTaskTimeout:
+		d.red.Printf("%s⏱ Task timed out\n", prefix)
+		if event.Task.TaskError != "" {
+			fmt.Printf("%s  Error: %s\n", prefix, event.Task.TaskError)
 		}
 
 	case eval.EventTaskError:
@@ -302,7 +321,12 @@ func displayTextResults(results []*eval.EvalResult) error {
 		if result.TaskPassed {
 			green.Printf("  Task Status: PASSED\n")
 		} else {
-			if result.AgentExecutionError {
+			if result.TimedOut {
+				red.Printf("  Task Status: FAILED (Timed out)\n")
+				if result.TaskError != "" {
+					fmt.Printf("  Error: %s\n", result.TaskError)
+				}
+			} else if result.AgentExecutionError {
 				red.Printf("  Task Status: FAILED (Agent execution error)\n")
 				if result.TaskError != "" || result.TaskOutput != "" {
 					errorFile, err := saveErrorToFile(result.TaskName, result.TaskError, result.TaskOutput)

--- a/pkg/eval/config.go
+++ b/pkg/eval/config.go
@@ -46,6 +46,10 @@ type EvalConfig struct {
 	McpConfigFile string                       `json:"mcpConfigFile"`
 	LLMJudge      *llmjudge.LLMJudgeEvalConfig `json:"llmJudge"`
 
+	// DefaultTaskLimits sets default timeout limits for all tasks in this eval.
+	// Individual tasks can override these via spec.limits.
+	DefaultTaskLimits *util.Limits `json:"defaultTaskLimits,omitempty"`
+
 	// Advanced mode: different assertion sets
 	TaskSets []TaskSet `json:"taskSets,omitempty"`
 }

--- a/pkg/eval/progress.go
+++ b/pkg/eval/progress.go
@@ -23,6 +23,7 @@ const (
 	EventTaskVerifying  ProgressEventType = "task_verifying"
 	EventTaskAssertions ProgressEventType = "task_assertions"
 	EventTaskComplete   ProgressEventType = "task_complete"
+	EventTaskTimeout    ProgressEventType = "task_timeout"
 	EventTaskError      ProgressEventType = "task_error"
 	EventEvalComplete   ProgressEventType = "eval_complete"
 )

--- a/pkg/eval/runner.go
+++ b/pkg/eval/runner.go
@@ -27,6 +27,7 @@ type EvalResult struct {
 	TaskPassed          bool                      `json:"taskPassed"`
 	TaskOutput          string                    `json:"taskOutput"`
 	TaskError           string                    `json:"taskError,omitempty"`
+	TimedOut            bool                      `json:"timedOut,omitempty"`
 	TaskJudgeReason     string                    `json:"taskJudgeReason,omitempty"`
 	TaskJudgeError      string                    `json:"taskJudgeError,omitempty"`
 	AgentExecutionError bool                      `json:"agentExecutionError,omitempty"` // True if agent failed to execute
@@ -62,6 +63,12 @@ type RunnerOptions struct {
 	ParallelWorkers   int
 	Runs              int  // Number of times to run each task (default: 1)
 	RunsExplicitlySet bool // True if Runs was explicitly set via CLI (overrides task-level runs)
+
+	// Timeout overrides (CLI flags)
+	DefaultTaskTimeout    string // Overrides eval config defaultTaskLimits.timeout for tasks without their own
+	TaskTimeout           string // Hard override for ALL task timeouts
+	DefaultCleanupTimeout string // Overrides eval config defaultTaskLimits.cleanupTimeout for tasks without their own
+	CleanupTimeout        string // Hard override for ALL cleanup timeouts
 }
 
 type evalRunner struct {
@@ -70,6 +77,12 @@ type evalRunner struct {
 	parallelWorkers   int
 	runs              int
 	runsExplicitlySet bool
+
+	// Timeout overrides from CLI
+	defaultTaskTimeout    string
+	taskTimeout           string
+	defaultCleanupTimeout string
+	cleanupTimeout        string
 }
 
 var _ EvalRunner = &evalRunner{}
@@ -99,13 +112,22 @@ func NewRunner(spec *EvalSpec, opts ...RunnerOptions) (EvalRunner, error) {
 		runsExplicitlySet = opts[0].RunsExplicitlySet
 	}
 
-	return &evalRunner{
+	r := &evalRunner{
 		spec:              spec,
 		progressCallback:  NoopProgressCallback,
 		parallelWorkers:   workers,
 		runs:              runs,
 		runsExplicitlySet: runsExplicitlySet,
-	}, nil
+	}
+
+	if len(opts) > 0 {
+		r.defaultTaskTimeout = opts[0].DefaultTaskTimeout
+		r.taskTimeout = opts[0].TaskTimeout
+		r.defaultCleanupTimeout = opts[0].DefaultCleanupTimeout
+		r.cleanupTimeout = opts[0].CleanupTimeout
+	}
+
+	return r, nil
 }
 
 func (r *evalRunner) loadMcpConfig() (*mcpclient.MCPConfig, error) {
@@ -383,6 +405,95 @@ func (r *evalRunner) getRunsForTask(tc taskConfig) int {
 	return 1
 }
 
+// resolveTaskTimeout determines the effective task timeout for a specific task.
+// Precedence (highest to lowest):
+//  1. CLI --task-timeout (hard override)
+//  2. task spec.limits.timeout (per-task)
+//  3. CLI --default-task-timeout
+//  4. eval config.defaultTaskLimits.timeout
+//  5. no timeout (returns 0, false, nil)
+func (r *evalRunner) resolveTaskTimeout(tc taskConfig) (time.Duration, bool, error) {
+	if r.taskTimeout != "" {
+		d, err := time.ParseDuration(r.taskTimeout)
+		if err != nil {
+			return 0, false, fmt.Errorf("invalid --task-timeout %q: %w", r.taskTimeout, err)
+		}
+		return d, true, nil
+	}
+
+	if tc.spec.Spec != nil && tc.spec.Spec.Limits != nil {
+		d, ok, err := tc.spec.Spec.Limits.GetTimeout()
+		if err != nil {
+			return 0, false, err
+		}
+		if ok {
+			return d, true, nil
+		}
+	}
+
+	if r.defaultTaskTimeout != "" {
+		d, err := time.ParseDuration(r.defaultTaskTimeout)
+		if err != nil {
+			return 0, false, fmt.Errorf("invalid --default-task-timeout %q: %w", r.defaultTaskTimeout, err)
+		}
+		return d, true, nil
+	}
+
+	if r.spec.Config.DefaultTaskLimits != nil {
+		d, ok, err := r.spec.Config.DefaultTaskLimits.GetTimeout()
+		if err != nil {
+			return 0, false, err
+		}
+		if ok {
+			return d, true, nil
+		}
+	}
+
+	return 0, false, nil
+}
+
+// resolveCleanupTimeout determines the effective cleanup timeout for a specific task.
+// Follows the same precedence pattern as resolveTaskTimeout.
+func (r *evalRunner) resolveCleanupTimeout(tc taskConfig) (time.Duration, bool, error) {
+	if r.cleanupTimeout != "" {
+		d, err := time.ParseDuration(r.cleanupTimeout)
+		if err != nil {
+			return 0, false, fmt.Errorf("invalid --cleanup-timeout %q: %w", r.cleanupTimeout, err)
+		}
+		return d, true, nil
+	}
+
+	if tc.spec.Spec != nil && tc.spec.Spec.Limits != nil {
+		d, ok, err := tc.spec.Spec.Limits.GetCleanupTimeout()
+		if err != nil {
+			return 0, false, err
+		}
+		if ok {
+			return d, true, nil
+		}
+	}
+
+	if r.defaultCleanupTimeout != "" {
+		d, err := time.ParseDuration(r.defaultCleanupTimeout)
+		if err != nil {
+			return 0, false, fmt.Errorf("invalid --default-cleanup-timeout %q: %w", r.defaultCleanupTimeout, err)
+		}
+		return d, true, nil
+	}
+
+	if r.spec.Config.DefaultTaskLimits != nil {
+		d, ok, err := r.spec.Config.DefaultTaskLimits.GetCleanupTimeout()
+		if err != nil {
+			return 0, false, err
+		}
+		if ok {
+			return d, true, nil
+		}
+	}
+
+	return 0, false, nil
+}
+
 // executeTask runs a task for the configured number of runs.
 // Returns a slice of results, one per run.
 func (r *evalRunner) executeTask(
@@ -484,6 +595,21 @@ func (r *evalRunner) runTask(
 		Parallel:   tc.spec.Metadata.Parallel,
 	}
 
+	// Resolve timeouts
+	taskTimeout, hasTaskTimeout, err := r.resolveTaskTimeout(tc)
+	if err != nil {
+		result.TaskPassed = false
+		result.TaskError = err.Error()
+		return result, nil
+	}
+
+	cleanupTimeout, hasCleanupTimeout, err := r.resolveCleanupTimeout(tc)
+	if err != nil {
+		result.TaskPassed = false
+		result.TaskError = err.Error()
+		return result, nil
+	}
+
 	r.progressCallback(ProgressEvent{
 		Type:    EventTaskStart,
 		Message: fmt.Sprintf("Starting task: %s", tc.spec.Metadata.Name),
@@ -496,21 +622,66 @@ func (r *evalRunner) runTask(
 		Task:    result,
 	})
 
-	taskRunner, manager, cleanup, err := r.setupTaskResources(ctx, tc, result)
+	// Create a task-scoped context with timeout if configured
+	taskCtx := ctx
+	var taskCancel context.CancelFunc
+	if hasTaskTimeout {
+		taskCtx, taskCancel = context.WithTimeout(ctx, taskTimeout)
+		defer taskCancel()
+	}
+
+	taskRunner, manager, cleanup, err := r.setupTaskResources(taskCtx, tc, result)
 	if err != nil {
 		result.TaskPassed = false
-		result.TaskError = err.Error()
-		r.progressCallback(ProgressEvent{
-			Type:    EventTaskError,
-			Message: fmt.Sprintf("Task setup failed: %s", tc.spec.Metadata.Name),
-			Task:    result,
-		})
+		// Check if the error was caused by timeout
+		if hasTaskTimeout && taskCtx.Err() == context.DeadlineExceeded {
+			result.TimedOut = true
+			result.TaskError = fmt.Sprintf("task exceeded timeout of %s during setup", taskTimeout)
+			r.progressCallback(ProgressEvent{
+				Type:    EventTaskTimeout,
+				Message: fmt.Sprintf("Task %s timed out after %s", tc.spec.Metadata.Name, taskTimeout),
+				Task:    result,
+			})
+		} else {
+			result.TaskError = err.Error()
+			r.progressCallback(ProgressEvent{
+				Type:    EventTaskError,
+				Message: fmt.Sprintf("Task setup failed: %s", tc.spec.Metadata.Name),
+				Task:    result,
+			})
+		}
 		return result, nil
 	}
-	defer cleanup()
 
-	r.executeTaskSteps(ctx, taskRunner, agentRunner, manager, result)
+	// Defer cleanup with its own timeout context, independent of task timeout
+	defer func() {
+		var cleanupCtx context.Context
+		var cleanupCancel context.CancelFunc
+		if hasCleanupTimeout {
+			cleanupCtx, cleanupCancel = context.WithTimeout(context.Background(), cleanupTimeout)
+		} else {
+			cleanupCtx = context.Background()
+			cleanupCancel = func() {}
+		}
+		defer cleanupCancel()
+		cleanup(cleanupCtx)
+	}()
 
+	r.executeTaskSteps(taskCtx, taskRunner, agentRunner, manager, result)
+
+	// Check if executeTaskSteps was terminated by timeout
+	if hasTaskTimeout && taskCtx.Err() == context.DeadlineExceeded && !result.TimedOut {
+		result.TimedOut = true
+		result.TaskPassed = false
+		result.TaskError = fmt.Sprintf("task exceeded timeout of %s", taskTimeout)
+		r.progressCallback(ProgressEvent{
+			Type:    EventTaskTimeout,
+			Message: fmt.Sprintf("Task %s timed out after %s", tc.spec.Metadata.Name, taskTimeout),
+			Task:    result,
+		})
+	}
+
+	// Assertions and token computation use the original ctx, not taskCtx
 	r.progressCallback(ProgressEvent{
 		Type:    EventTaskAssertions,
 		Message: fmt.Sprintf("Evaluating assertions for task: %s", tc.spec.Metadata.Name),
@@ -563,7 +734,7 @@ func (r *evalRunner) setupTaskResources(
 	ctx context.Context,
 	tc taskConfig,
 	result *EvalResult,
-) (task.TaskRunner, mcpproxy.ServerManager, func(), error) {
+) (task.TaskRunner, mcpproxy.ServerManager, func(context.Context), error) {
 	mcpManager, ok := mcpclient.ManagerFromContext(ctx)
 	if !ok {
 		return nil, nil, nil, fmt.Errorf("mcp manager not found in context")
@@ -590,8 +761,8 @@ func (r *evalRunner) setupTaskResources(
 		return nil, nil, nil, fmt.Errorf("failed to setup task: %w", err)
 	}
 
-	cleanup := func() {
-		cleanupOutput, _ := taskRunner.Cleanup(ctx)
+	cleanup := func(cleanupCtx context.Context) {
+		cleanupOutput, _ := taskRunner.Cleanup(cleanupCtx)
 		result.CleanupOutput = cleanupOutput
 		manager.Close()
 	}

--- a/pkg/eval/runner_test.go
+++ b/pkg/eval/runner_test.go
@@ -1,13 +1,20 @@
 package eval
 
 import (
+	"context"
 	"os"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/mcpchecker/mcpchecker/pkg/agent"
+	"github.com/mcpchecker/mcpchecker/pkg/extension/client"
+	extSpec "github.com/mcpchecker/mcpchecker/pkg/extension"
 	"github.com/mcpchecker/mcpchecker/pkg/mcpclient"
+	"github.com/mcpchecker/mcpchecker/pkg/mcpproxy"
 	"github.com/mcpchecker/mcpchecker/pkg/task"
+	"github.com/mcpchecker/mcpchecker/pkg/tokens"
+	"github.com/mcpchecker/mcpchecker/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -377,58 +384,76 @@ func TestNewRunnerWithOptions(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		opts                     []RunnerOptions
-		expectedWorkers          int
-		expectedRuns             int
-		expectedRunsExplicitlySet bool
+		opts                          []RunnerOptions
+		expectedWorkers               int
+		expectedRuns                  int
+		expectedRunsExplicitlySet     bool
+		expectedDefaultTaskTimeout    string
+		expectedTaskTimeout           string
+		expectedDefaultCleanupTimeout string
+		expectedCleanupTimeout        string
 	}{
 		"no options - defaults to 1": {
-			opts:                     nil,
-			expectedWorkers:          1,
-			expectedRuns:             1,
+			opts:                      nil,
+			expectedWorkers:           1,
+			expectedRuns:              1,
 			expectedRunsExplicitlySet: false,
 		},
 		"empty options - defaults to 1": {
-			opts:                     []RunnerOptions{{}},
-			expectedWorkers:          1,
-			expectedRuns:             1,
+			opts:                      []RunnerOptions{{}},
+			expectedWorkers:           1,
+			expectedRuns:              1,
 			expectedRunsExplicitlySet: false,
 		},
 		"zero workers - defaults to 1": {
-			opts:                     []RunnerOptions{{ParallelWorkers: 0}},
-			expectedWorkers:          1,
-			expectedRuns:             1,
+			opts:                      []RunnerOptions{{ParallelWorkers: 0}},
+			expectedWorkers:           1,
+			expectedRuns:              1,
 			expectedRunsExplicitlySet: false,
 		},
 		"negative workers - defaults to 1": {
-			opts:                     []RunnerOptions{{ParallelWorkers: -5}},
-			expectedWorkers:          1,
-			expectedRuns:             1,
+			opts:                      []RunnerOptions{{ParallelWorkers: -5}},
+			expectedWorkers:           1,
+			expectedRuns:              1,
 			expectedRunsExplicitlySet: false,
 		},
 		"valid workers": {
-			opts:                     []RunnerOptions{{ParallelWorkers: 4}},
-			expectedWorkers:          4,
-			expectedRuns:             1,
+			opts:                      []RunnerOptions{{ParallelWorkers: 4}},
+			expectedWorkers:           4,
+			expectedRuns:              1,
 			expectedRunsExplicitlySet: false,
 		},
 		"valid runs": {
-			opts:                     []RunnerOptions{{Runs: 5}},
-			expectedWorkers:          1,
-			expectedRuns:             5,
+			opts:                      []RunnerOptions{{Runs: 5}},
+			expectedWorkers:           1,
+			expectedRuns:              5,
 			expectedRunsExplicitlySet: false,
 		},
 		"runs explicitly set": {
-			opts:                     []RunnerOptions{{Runs: 3, RunsExplicitlySet: true}},
-			expectedWorkers:          1,
-			expectedRuns:             3,
+			opts:                      []RunnerOptions{{Runs: 3, RunsExplicitlySet: true}},
+			expectedWorkers:           1,
+			expectedRuns:              3,
 			expectedRunsExplicitlySet: true,
 		},
 		"all options set": {
-			opts:                     []RunnerOptions{{ParallelWorkers: 4, Runs: 5, RunsExplicitlySet: true}},
-			expectedWorkers:          4,
-			expectedRuns:             5,
+			opts:                      []RunnerOptions{{ParallelWorkers: 4, Runs: 5, RunsExplicitlySet: true}},
+			expectedWorkers:           4,
+			expectedRuns:              5,
 			expectedRunsExplicitlySet: true,
+		},
+		"timeout options set": {
+			opts: []RunnerOptions{{
+				DefaultTaskTimeout:    "10m",
+				TaskTimeout:           "5m",
+				DefaultCleanupTimeout: "2m",
+				CleanupTimeout:        "1m",
+			}},
+			expectedWorkers:               1,
+			expectedRuns:                  1,
+			expectedDefaultTaskTimeout:    "10m",
+			expectedTaskTimeout:           "5m",
+			expectedDefaultCleanupTimeout: "2m",
+			expectedCleanupTimeout:        "1m",
 		},
 	}
 
@@ -441,6 +466,10 @@ func TestNewRunnerWithOptions(t *testing.T) {
 			assert.Equal(t, tc.expectedWorkers, r.parallelWorkers)
 			assert.Equal(t, tc.expectedRuns, r.runs)
 			assert.Equal(t, tc.expectedRunsExplicitlySet, r.runsExplicitlySet)
+			assert.Equal(t, tc.expectedDefaultTaskTimeout, r.defaultTaskTimeout)
+			assert.Equal(t, tc.expectedTaskTimeout, r.taskTimeout)
+			assert.Equal(t, tc.expectedDefaultCleanupTimeout, r.defaultCleanupTimeout)
+			assert.Equal(t, tc.expectedCleanupTimeout, r.cleanupTimeout)
 		})
 	}
 }
@@ -620,20 +649,20 @@ func TestCollectTaskConfigsDeduplication(t *testing.T) {
 				{Glob: "../task/testdata/*.yaml"},
 				{Glob: "../task/testdata/*.yaml"}, // same glob twice
 			},
-			expectedCount: 2, // 2 unique files, duplicates removed
+			expectedCount: 3, // 3 unique files, duplicates removed
 		},
 		"overlapping glob and explicit path": {
 			taskSets: []TaskSet{
 				{Glob: "../task/testdata/*.yaml"},
 				{Path: "../task/testdata/create-pod-inline.yaml"}, // explicit path that matches glob
 			},
-			expectedCount: 2, // should deduplicate the overlapping one
+			expectedCount: 3, // should deduplicate the overlapping one
 		},
 		"single task set": {
 			taskSets: []TaskSet{
 				{Glob: "../task/testdata/*.yaml"},
 			},
-			expectedCount: 2, // 2 task files in testdata
+			expectedCount: 3, // 3 task files in testdata
 		},
 		"triple duplicate same path": {
 			taskSets: []TaskSet{
@@ -736,4 +765,385 @@ func TestCollectTaskConfigsNilAssertions(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, configs, 1)
 	assert.Len(t, configs[0].assertions, 0, "nil assertions should not be added to slice")
+}
+
+func TestResolveTaskTimeout(t *testing.T) {
+	tests := map[string]struct {
+		taskTimeout        string
+		specLimits         *util.Limits
+		defaultTaskTimeout string
+		configLimits       *util.Limits
+		expectedDuration   time.Duration
+		expectedSet        bool
+		expectErr          bool
+	}{
+		"all empty - no timeout": {
+			expectedDuration: 0,
+			expectedSet:      false,
+		},
+		"eval config only": {
+			configLimits:     &util.Limits{Timeout: "20m"},
+			expectedDuration: 20 * time.Minute,
+			expectedSet:      true,
+		},
+		"CLI default only": {
+			defaultTaskTimeout: "10m",
+			expectedDuration:   10 * time.Minute,
+			expectedSet:        true,
+		},
+		"CLI default overrides eval config": {
+			defaultTaskTimeout: "10m",
+			configLimits:       &util.Limits{Timeout: "20m"},
+			expectedDuration:   10 * time.Minute,
+			expectedSet:        true,
+		},
+		"per-task only": {
+			specLimits:       &util.Limits{Timeout: "5m"},
+			expectedDuration: 5 * time.Minute,
+			expectedSet:      true,
+		},
+		"per-task overrides CLI default": {
+			specLimits:         &util.Limits{Timeout: "5m"},
+			defaultTaskTimeout: "10m",
+			configLimits:       &util.Limits{Timeout: "20m"},
+			expectedDuration:   5 * time.Minute,
+			expectedSet:        true,
+		},
+		"per-task overrides eval config": {
+			specLimits:       &util.Limits{Timeout: "5m"},
+			configLimits:     &util.Limits{Timeout: "20m"},
+			expectedDuration: 5 * time.Minute,
+			expectedSet:      true,
+		},
+		"CLI hard override wins over all": {
+			taskTimeout:        "3m",
+			specLimits:         &util.Limits{Timeout: "5m"},
+			defaultTaskTimeout: "10m",
+			configLimits:       &util.Limits{Timeout: "20m"},
+			expectedDuration:   3 * time.Minute,
+			expectedSet:        true,
+		},
+		"CLI hard override with no others set": {
+			taskTimeout:      "3m",
+			expectedDuration: 3 * time.Minute,
+			expectedSet:      true,
+		},
+		"invalid CLI hard override": {
+			taskTimeout: "abc",
+			expectErr:   true,
+		},
+		"invalid per-task timeout": {
+			specLimits: &util.Limits{Timeout: "abc"},
+			expectErr:  true,
+		},
+		"invalid CLI default": {
+			defaultTaskTimeout: "abc",
+			expectErr:          true,
+		},
+		"invalid eval config": {
+			configLimits: &util.Limits{Timeout: "abc"},
+			expectErr:    true,
+		},
+		"per-task with empty timeout falls through to CLI default": {
+			specLimits:         &util.Limits{CleanupTimeout: "2m"}, // has limits but no timeout
+			defaultTaskTimeout: "10m",
+			expectedDuration:   10 * time.Minute,
+			expectedSet:        true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			runner := &evalRunner{
+				taskTimeout:        tc.taskTimeout,
+				defaultTaskTimeout: tc.defaultTaskTimeout,
+				spec: &EvalSpec{
+					Config: EvalConfig{
+						DefaultTaskLimits: tc.configLimits,
+					},
+				},
+			}
+			taskCfg := taskConfig{
+				spec: &task.TaskConfig{
+					Spec: &task.TaskSpec{
+						Limits: tc.specLimits,
+					},
+				},
+			}
+
+			d, ok, err := runner.resolveTaskTimeout(taskCfg)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedDuration, d)
+			assert.Equal(t, tc.expectedSet, ok)
+		})
+	}
+}
+
+func TestResolveCleanupTimeout(t *testing.T) {
+	tests := map[string]struct {
+		cleanupTimeout        string
+		specLimits            *util.Limits
+		defaultCleanupTimeout string
+		configLimits          *util.Limits
+		expectedDuration      time.Duration
+		expectedSet           bool
+		expectErr             bool
+	}{
+		"all empty - no timeout": {
+			expectedDuration: 0,
+			expectedSet:      false,
+		},
+		"eval config only": {
+			configLimits:     &util.Limits{CleanupTimeout: "5m"},
+			expectedDuration: 5 * time.Minute,
+			expectedSet:      true,
+		},
+		"CLI default only": {
+			defaultCleanupTimeout: "3m",
+			expectedDuration:      3 * time.Minute,
+			expectedSet:           true,
+		},
+		"CLI default overrides eval config": {
+			defaultCleanupTimeout: "3m",
+			configLimits:          &util.Limits{CleanupTimeout: "5m"},
+			expectedDuration:      3 * time.Minute,
+			expectedSet:           true,
+		},
+		"per-task only": {
+			specLimits:       &util.Limits{CleanupTimeout: "2m"},
+			expectedDuration: 2 * time.Minute,
+			expectedSet:      true,
+		},
+		"per-task overrides CLI default": {
+			specLimits:            &util.Limits{CleanupTimeout: "2m"},
+			defaultCleanupTimeout: "3m",
+			configLimits:          &util.Limits{CleanupTimeout: "5m"},
+			expectedDuration:      2 * time.Minute,
+			expectedSet:           true,
+		},
+		"CLI hard override wins over all": {
+			cleanupTimeout:        "1m",
+			specLimits:            &util.Limits{CleanupTimeout: "2m"},
+			defaultCleanupTimeout: "3m",
+			configLimits:          &util.Limits{CleanupTimeout: "5m"},
+			expectedDuration:      1 * time.Minute,
+			expectedSet:           true,
+		},
+		"CLI hard override with no others set": {
+			cleanupTimeout:   "1m",
+			expectedDuration: 1 * time.Minute,
+			expectedSet:      true,
+		},
+		"invalid CLI hard override": {
+			cleanupTimeout: "abc",
+			expectErr:      true,
+		},
+		"invalid per-task cleanup timeout": {
+			specLimits: &util.Limits{CleanupTimeout: "abc"},
+			expectErr:  true,
+		},
+		"invalid CLI default": {
+			defaultCleanupTimeout: "abc",
+			expectErr:             true,
+		},
+		"invalid eval config": {
+			configLimits: &util.Limits{CleanupTimeout: "abc"},
+			expectErr:    true,
+		},
+		"per-task with empty cleanupTimeout falls through to CLI default": {
+			specLimits:            &util.Limits{Timeout: "10m"}, // has limits but no cleanupTimeout
+			defaultCleanupTimeout: "3m",
+			expectedDuration:      3 * time.Minute,
+			expectedSet:           true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			runner := &evalRunner{
+				cleanupTimeout:        tc.cleanupTimeout,
+				defaultCleanupTimeout: tc.defaultCleanupTimeout,
+				spec: &EvalSpec{
+					Config: EvalConfig{
+						DefaultTaskLimits: tc.configLimits,
+					},
+				},
+			}
+			taskCfg := taskConfig{
+				spec: &task.TaskConfig{
+					Spec: &task.TaskSpec{
+						Limits: tc.specLimits,
+					},
+				},
+			}
+
+			d, ok, err := runner.resolveCleanupTimeout(taskCfg)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedDuration, d)
+			assert.Equal(t, tc.expectedSet, ok)
+		})
+	}
+}
+
+// --- Test fakes for integration tests ---
+
+// fakeAgentResult implements agent.AgentResult
+type fakeAgentResult struct{}
+
+func (f *fakeAgentResult) GetOutput() []agent.OutputStep {
+	return []agent.OutputStep{{Type: "message", Content: "done"}}
+}
+func (f *fakeAgentResult) GetToolCalls() []agent.ToolCallSummary { return nil }
+func (f *fakeAgentResult) GetRawUpdates() any                    { return nil }
+func (f *fakeAgentResult) GetTokenEstimate() tokens.Estimate     { return tokens.Estimate{} }
+
+// fakeAgentRunner implements agent.Runner. RunTask blocks until context is cancelled or delay elapses.
+type fakeAgentRunner struct {
+	delay time.Duration
+}
+
+func (f *fakeAgentRunner) RunTask(ctx context.Context, prompt string) (agent.AgentResult, error) {
+	select {
+	case <-time.After(f.delay):
+		return &fakeAgentResult{}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (f *fakeAgentRunner) WithMcpServerInfo(_ mcpproxy.ServerManager) agent.Runner {
+	return f
+}
+
+func (f *fakeAgentRunner) AgentName() string {
+	return "fake-agent"
+}
+
+// fakeMcpManager implements mcpclient.Manager
+type fakeMcpManager struct{}
+
+func (f *fakeMcpManager) Get(_ string) (*mcpclient.Client, bool) { return nil, false }
+func (f *fakeMcpManager) GetAll() map[string]*mcpclient.Client   { return map[string]*mcpclient.Client{} }
+func (f *fakeMcpManager) Close(_ context.Context) error          { return nil }
+
+// fakeExtensionManager implements client.ExtensionManager
+type fakeExtensionManager struct{}
+
+func (f *fakeExtensionManager) Register(_ string, _ *extSpec.ExtensionSpec) error { return nil }
+func (f *fakeExtensionManager) Get(_ context.Context, _ string) (client.Client, error) {
+	return nil, nil
+}
+func (f *fakeExtensionManager) Has(_ string) bool              { return false }
+func (f *fakeExtensionManager) ShutdownAll(_ context.Context) error { return nil }
+
+// setupTestContext creates a context with fake MCP and extension managers injected
+func setupTestContext() context.Context {
+	ctx := context.Background()
+	ctx = mcpclient.ManagerToContext(ctx, &fakeMcpManager{})
+	ctx = client.ManagerToContext(ctx, &fakeExtensionManager{})
+	return ctx
+}
+
+func TestRunTaskTimeout(t *testing.T) {
+	tests := map[string]struct {
+		taskTimeout   string
+		agentDelay    time.Duration
+		expectTimeout bool
+	}{
+		"task completes within timeout": {
+			taskTimeout:   "5s",
+			agentDelay:    10 * time.Millisecond,
+			expectTimeout: false,
+		},
+		"task exceeds timeout": {
+			taskTimeout:   "100ms",
+			agentDelay:    10 * time.Second,
+			expectTimeout: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := setupTestContext()
+
+			runner := &evalRunner{
+				spec: &EvalSpec{
+					Config: EvalConfig{},
+				},
+				taskTimeout:      tc.taskTimeout,
+				progressCallback: NoopProgressCallback,
+			}
+
+			taskCfg := taskConfig{
+				path: "test.yaml",
+				spec: &task.TaskConfig{
+					Metadata: task.TaskMetadata{
+						Name: "timeout-test",
+					},
+					Spec: &task.TaskSpec{
+						Prompt: &util.Step{Inline: "do something"},
+					},
+				},
+			}
+
+			agentRunner := &fakeAgentRunner{delay: tc.agentDelay}
+
+			result, err := runner.runTask(ctx, agentRunner, taskCfg)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			assert.Equal(t, tc.expectTimeout, result.TimedOut)
+			if tc.expectTimeout {
+				assert.False(t, result.TaskPassed)
+				assert.Contains(t, result.TaskError, "task exceeded timeout")
+			} else {
+				assert.True(t, result.TaskPassed)
+			}
+		})
+	}
+}
+
+func TestRunTaskCleanupRunsAfterTimeout(t *testing.T) {
+	ctx := setupTestContext()
+
+	runner := &evalRunner{
+		spec: &EvalSpec{
+			Config: EvalConfig{},
+		},
+		taskTimeout:      "100ms",
+		progressCallback: NoopProgressCallback,
+	}
+
+	taskCfg := taskConfig{
+		path: "test.yaml",
+		spec: &task.TaskConfig{
+			Metadata: task.TaskMetadata{
+				Name: "cleanup-after-timeout",
+			},
+			Spec: &task.TaskSpec{
+				Prompt: &util.Step{Inline: "do something"},
+			},
+		},
+	}
+
+	agentRunner := &fakeAgentRunner{delay: 10 * time.Second}
+
+	result, err := runner.runTask(ctx, agentRunner, taskCfg)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.True(t, result.TimedOut)
+	assert.False(t, result.TaskPassed)
+
+	// Cleanup should have run (cleanup output is set even with no cleanup steps)
+	assert.NotNil(t, result.CleanupOutput, "cleanup should run even after timeout")
+	assert.True(t, result.CleanupOutput.Success, "cleanup with no steps should succeed")
 }

--- a/pkg/task/config.go
+++ b/pkg/task/config.go
@@ -36,6 +36,7 @@ type TaskMetadata struct {
 
 type TaskSpec struct {
 	Requires []Requirements      `json:"requires,omitempty"`
+	Limits   *util.Limits        `json:"limits,omitempty"`
 	Setup    []*steps.StepConfig `json:"setup,omitempty"`
 	Cleanup  []*steps.StepConfig `json:"cleanup,omitempty"`
 	Verify   []*steps.StepConfig `json:"verify,omitempty"`

--- a/pkg/task/config_test.go
+++ b/pkg/task/config_test.go
@@ -37,6 +37,44 @@ func TestFromFile(t *testing.T) {
 		expected  *TaskConfig
 		expectErr bool
 	}{
+		"task with limits": {
+			file: "task-with-limits.yaml",
+			expected: &TaskConfig{
+				TypeMeta: util.TypeMeta{
+					APIVersion: "mcpchecker/v1alpha2",
+					Kind:       KindTask,
+				},
+				Metadata: TaskMetadata{
+					Name:       "task with limits",
+					Difficulty: DifficultyMedium,
+				},
+				Spec: &TaskSpec{
+					Limits: &util.Limits{
+						Timeout:        "15m",
+						CleanupTimeout: "2m",
+					},
+					Setup: []*steps.StepConfig{{
+						Config: map[string]json.RawMessage{
+							"script": json.RawMessage(`{"inline":"echo setup"}`),
+						},
+					}},
+					Verify: []*steps.StepConfig{{
+						Config: map[string]json.RawMessage{
+							"script": json.RawMessage(`{"inline":"echo verify"}`),
+						},
+					}},
+					Cleanup: []*steps.StepConfig{{
+						Config: map[string]json.RawMessage{
+							"script": json.RawMessage(`{"inline":"echo cleanup"}`),
+						},
+					}},
+					Prompt: &util.Step{
+						Inline: "Do something",
+					},
+				},
+				basePath: basePath,
+			},
+		},
 		"create pod inline no verify": {
 			file: "create-pod-inline-no-verify.yaml",
 			expected: &TaskConfig{

--- a/pkg/task/testdata/task-with-limits.yaml
+++ b/pkg/task/testdata/task-with-limits.yaml
@@ -1,0 +1,20 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  name: "task with limits"
+  difficulty: medium
+spec:
+  limits:
+    timeout: "15m"
+    cleanupTimeout: "2m"
+  setup:
+    - script:
+        inline: "echo setup"
+  verify:
+    - script:
+        inline: "echo verify"
+  cleanup:
+    - script:
+        inline: "echo cleanup"
+  prompt:
+    inline: "Do something"

--- a/pkg/util/limits.go
+++ b/pkg/util/limits.go
@@ -18,10 +18,16 @@ func (l *Limits) GetTimeout() (time.Duration, bool, error) {
 	if l == nil || l.Timeout == "" {
 		return 0, false, nil
 	}
+
 	d, err := time.ParseDuration(l.Timeout)
 	if err != nil {
 		return 0, false, fmt.Errorf("invalid timeout %q: %w", l.Timeout, err)
 	}
+
+	if d <= 0 {
+		return 0, false, fmt.Errorf("invalid timeout: timeout duration must be > 0, got %q", l.Timeout)
+	}
+
 	return d, true, nil
 }
 
@@ -32,9 +38,15 @@ func (l *Limits) GetCleanupTimeout() (time.Duration, bool, error) {
 	if l == nil || l.CleanupTimeout == "" {
 		return 0, false, nil
 	}
+
 	d, err := time.ParseDuration(l.CleanupTimeout)
 	if err != nil {
 		return 0, false, fmt.Errorf("invalid cleanupTimeout %q: %w", l.CleanupTimeout, err)
 	}
+
+	if d <= 0 {
+		return 0, false, fmt.Errorf("invalid timeout: timeout duration must be > 0, got %q", l.Timeout)
+	}
+
 	return d, true, nil
 }

--- a/pkg/util/limits.go
+++ b/pkg/util/limits.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"fmt"
+	"time"
+)
+
+// Limits configures timeout constraints for task execution.
+type Limits struct {
+	Timeout        string `json:"timeout,omitempty"`
+	CleanupTimeout string `json:"cleanupTimeout,omitempty"`
+}
+
+// GetTimeout parses the Timeout field as a time.Duration.
+// Returns (duration, true, nil) if set and valid, or (0, false, nil) if not set.
+// Returns an error if the string is set but cannot be parsed.
+func (l *Limits) GetTimeout() (time.Duration, bool, error) {
+	if l == nil || l.Timeout == "" {
+		return 0, false, nil
+	}
+	d, err := time.ParseDuration(l.Timeout)
+	if err != nil {
+		return 0, false, fmt.Errorf("invalid timeout %q: %w", l.Timeout, err)
+	}
+	return d, true, nil
+}
+
+// GetCleanupTimeout parses the CleanupTimeout field as a time.Duration.
+// Returns (duration, true, nil) if set and valid, or (0, false, nil) if not set.
+// Returns an error if the string is set but cannot be parsed.
+func (l *Limits) GetCleanupTimeout() (time.Duration, bool, error) {
+	if l == nil || l.CleanupTimeout == "" {
+		return 0, false, nil
+	}
+	d, err := time.ParseDuration(l.CleanupTimeout)
+	if err != nil {
+		return 0, false, fmt.Errorf("invalid cleanupTimeout %q: %w", l.CleanupTimeout, err)
+	}
+	return d, true, nil
+}

--- a/pkg/util/limits_test.go
+++ b/pkg/util/limits_test.go
@@ -1,0 +1,128 @@
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimits_GetTimeout(t *testing.T) {
+	tests := map[string]struct {
+		limits   *Limits
+		expected time.Duration
+		isSet    bool
+		hasErr   bool
+	}{
+		"nil Limits": {
+			limits:   nil,
+			expected: 0,
+			isSet:    false,
+		},
+		"empty timeout": {
+			limits:   &Limits{Timeout: ""},
+			expected: 0,
+			isSet:    false,
+		},
+		"valid minutes": {
+			limits:   &Limits{Timeout: "15m"},
+			expected: 15 * time.Minute,
+			isSet:    true,
+		},
+		"valid seconds": {
+			limits:   &Limits{Timeout: "30s"},
+			expected: 30 * time.Second,
+			isSet:    true,
+		},
+		"valid compound duration": {
+			limits:   &Limits{Timeout: "1h30m"},
+			expected: 90 * time.Minute,
+			isSet:    true,
+		},
+		"valid milliseconds": {
+			limits:   &Limits{Timeout: "500ms"},
+			expected: 500 * time.Millisecond,
+			isSet:    true,
+		},
+		"invalid duration": {
+			limits: &Limits{Timeout: "abc"},
+			hasErr: true,
+		},
+		"number without unit": {
+			limits: &Limits{Timeout: "30"},
+			hasErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			d, ok, err := tc.limits.GetTimeout()
+			if tc.hasErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid timeout")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, d)
+			assert.Equal(t, tc.isSet, ok)
+		})
+	}
+}
+
+func TestLimits_GetCleanupTimeout(t *testing.T) {
+	tests := map[string]struct {
+		limits   *Limits
+		expected time.Duration
+		isSet    bool
+		hasErr   bool
+	}{
+		"nil Limits": {
+			limits:   nil,
+			expected: 0,
+			isSet:    false,
+		},
+		"empty cleanupTimeout": {
+			limits:   &Limits{CleanupTimeout: ""},
+			expected: 0,
+			isSet:    false,
+		},
+		"valid minutes": {
+			limits:   &Limits{CleanupTimeout: "5m"},
+			expected: 5 * time.Minute,
+			isSet:    true,
+		},
+		"valid seconds": {
+			limits:   &Limits{CleanupTimeout: "30s"},
+			expected: 30 * time.Second,
+			isSet:    true,
+		},
+		"valid compound duration": {
+			limits:   &Limits{CleanupTimeout: "2m30s"},
+			expected: 2*time.Minute + 30*time.Second,
+			isSet:    true,
+		},
+		"invalid duration": {
+			limits: &Limits{CleanupTimeout: "abc"},
+			hasErr: true,
+		},
+		"number without unit": {
+			limits: &Limits{CleanupTimeout: "30"},
+			hasErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			d, ok, err := tc.limits.GetCleanupTimeout()
+			if tc.hasErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid cleanupTimeout")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, d)
+			assert.Equal(t, tc.isSet, ok)
+		})
+	}
+}

--- a/pkg/util/limits_test.go
+++ b/pkg/util/limits_test.go
@@ -53,6 +53,10 @@ func TestLimits_GetTimeout(t *testing.T) {
 			limits: &Limits{Timeout: "30"},
 			hasErr: true,
 		},
+		"negative duration": {
+			limits: &Limits{Timeout: "-30s"},
+			hasErr: true,
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
Fixes #251 #103 

This PR adds support for configurable timeouts at a few levels:
1. Default timeout for arbitrary tasks
2. Per task specific timeouts (maybe a task needs longer)
3. Default cleanup timeout for arbitrary tasks
4. Per task specific cleanup timeout

This is configurable both within the yaml and with CLI flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable task timeouts: per-task limits, eval-level defaults, CLI overrides, and a separate cleanup timeout that still runs after a task times out. Timed-out tasks are reported distinctly in CLI results.

* **Documentation**
  * Added docs and CLI help describing timeout fields, flags, precedence, and interaction with step-level timeouts.

* **Tests**
  * Added unit and integration tests for parsing, precedence resolution, runtime timeout behavior, and cleanup execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->