### PR TITLE
feat(cli)!: nest commands under result command

### DIFF
--- a/.github/actions/mcpchecker-action/action.yaml
+++ b/.github/actions/mcpchecker-action/action.yaml
@@ -178,17 +178,17 @@ runs:
         echo "results-file=$RESULTS_FILE" >> $GITHUB_OUTPUT
 
         # Output metrics in GitHub Actions format
-        "$MCPCHECKER" summary "$RESULTS_FILE" --github-output >> $GITHUB_OUTPUT
+        "$MCPCHECKER" result summary "$RESULTS_FILE" --github-output >> $GITHUB_OUTPUT
 
         # Display human-readable summary
-        "$MCPCHECKER" summary "$RESULTS_FILE"
+        "$MCPCHECKER" result summary "$RESULTS_FILE"
 
         # Verify thresholds
         TASK_THRESHOLD="${{ inputs.task-pass-threshold }}"
         ASSERTION_THRESHOLD="${{ inputs.assertion-pass-threshold }}"
 
         set +e
-        "$MCPCHECKER" verify "$RESULTS_FILE" --task "$TASK_THRESHOLD" --assertion "$ASSERTION_THRESHOLD"
+        "$MCPCHECKER" result verify "$RESULTS_FILE" --task "$TASK_THRESHOLD" --assertion "$ASSERTION_THRESHOLD"
         VERIFY_EXIT_CODE=$?
         set -e
 

--- a/.github/actions/mcpchecker-diff-action/action.yaml
+++ b/.github/actions/mcpchecker-diff-action/action.yaml
@@ -66,7 +66,7 @@ runs:
 
         # Capture diff output
         set +e
-        DIFF_OUTPUT=$("$MCPCHECKER" diff --base "$BASE" --current "$CURRENT" --output markdown)
+        DIFF_OUTPUT=$("$MCPCHECKER" result diff --base "$BASE" --current "$CURRENT" --output markdown)
         DIFF_EXIT=$?
         set -e
 

--- a/docs/reference/cli/mcpchecker.md
+++ b/docs/reference/cli/mcpchecker.md
@@ -16,9 +16,6 @@ It runs agents through defined tasks and validates their behavior using assertio
 ### SEE ALSO
 
 * [mcpchecker check](mcpchecker_check.md)	 - Run an evaluation
-* [mcpchecker diff](mcpchecker_diff.md)	 - Compare two evaluation results
-* [mcpchecker summary](mcpchecker_summary.md)	 - Show a compact summary of evaluation results
-* [mcpchecker verify](mcpchecker_verify.md)	 - Verify evaluation results meet thresholds
+* [mcpchecker result](mcpchecker_result.md)	 - Commands for inspecting and analyzing evaluation result files
 * [mcpchecker version](mcpchecker_version.md)	 - Print version information
-* [mcpchecker view](mcpchecker_view.md)	 - Pretty-print evaluation results from a JSON file
 

--- a/docs/reference/cli/mcpchecker_result.md
+++ b/docs/reference/cli/mcpchecker_result.md
@@ -1,0 +1,24 @@
+## mcpchecker result
+
+Commands for inspecting and analyzing evaluation result files
+
+### Synopsis
+
+Commands for inspecting and analyzing evaluation result files.
+
+These commands operate on the JSON result files produced by 'mcpchecker check'.
+
+### Options
+
+```
+  -h, --help   help for result
+```
+
+### SEE ALSO
+
+* [mcpchecker](mcpchecker.md)	 - MCP evaluation framework
+* [mcpchecker result diff](mcpchecker_result_diff.md)	 - Compare two evaluation results
+* [mcpchecker result summary](mcpchecker_result_summary.md)	 - Show a compact summary of evaluation results
+* [mcpchecker result verify](mcpchecker_result_verify.md)	 - Verify evaluation results meet thresholds
+* [mcpchecker result view](mcpchecker_result_view.md)	 - Pretty-print evaluation results from a JSON file
+

--- a/docs/reference/cli/mcpchecker_result_diff.md
+++ b/docs/reference/cli/mcpchecker_result_diff.md
@@ -1,4 +1,4 @@
-## mcpchecker diff
+## mcpchecker result diff
 
 Compare two evaluation results
 
@@ -10,11 +10,11 @@ Shows regressions, improvements, new tasks, removed tasks, and overall pass rate
 Useful for posting on pull requests to show impact of changes.
 
 Example:
-  mcpchecker diff --base results-main.json --current results-pr.json
-  mcpchecker diff --base results-main.json --current results-pr.json --output markdown
+  mcpchecker result diff --base results-main.json --current results-pr.json
+  mcpchecker result diff --base results-main.json --current results-pr.json --output markdown
 
 ```
-mcpchecker diff --base <results-file> --current <results-file> [flags]
+mcpchecker result diff --base <results-file> --current <results-file> [flags]
 ```
 
 ### Options
@@ -28,5 +28,5 @@ mcpchecker diff --base <results-file> --current <results-file> [flags]
 
 ### SEE ALSO
 
-* [mcpchecker](mcpchecker.md)	 - MCP evaluation framework
+* [mcpchecker result](mcpchecker_result.md)	 - Commands for inspecting and analyzing evaluation result files
 

--- a/docs/reference/cli/mcpchecker_result_summary.md
+++ b/docs/reference/cli/mcpchecker_result_summary.md
@@ -1,4 +1,4 @@
-## mcpchecker summary
+## mcpchecker result summary
 
 Show a compact summary of evaluation results
 
@@ -12,7 +12,7 @@ Supports multiple output formats:
   - --github-output: GitHub Actions format (key=value)
 
 ```
-mcpchecker summary <results-file> [flags]
+mcpchecker result summary <results-file> [flags]
 ```
 
 ### Options
@@ -26,5 +26,5 @@ mcpchecker summary <results-file> [flags]
 
 ### SEE ALSO
 
-* [mcpchecker](mcpchecker.md)	 - MCP evaluation framework
+* [mcpchecker result](mcpchecker_result.md)	 - Commands for inspecting and analyzing evaluation result files
 

--- a/docs/reference/cli/mcpchecker_result_verify.md
+++ b/docs/reference/cli/mcpchecker_result_verify.md
@@ -1,4 +1,4 @@
-## mcpchecker verify
+## mcpchecker result verify
 
 Verify evaluation results meet thresholds
 
@@ -8,10 +8,10 @@ Verify that evaluation results meet minimum pass rate thresholds.
 Useful as a CI gate to enforce quality standards.
 
 Exits with code 0 if all thresholds are met, code 1 otherwise.
-Use 'mcpchecker summary' to view detailed results.
+Use 'mcpchecker result summary' to view detailed results.
 
 ```
-mcpchecker verify <results-file> [flags]
+mcpchecker result verify <results-file> [flags]
 ```
 
 ### Options
@@ -24,5 +24,5 @@ mcpchecker verify <results-file> [flags]
 
 ### SEE ALSO
 
-* [mcpchecker](mcpchecker.md)	 - MCP evaluation framework
+* [mcpchecker result](mcpchecker_result.md)	 - Commands for inspecting and analyzing evaluation result files
 

--- a/docs/reference/cli/mcpchecker_result_view.md
+++ b/docs/reference/cli/mcpchecker_result_view.md
@@ -1,17 +1,17 @@
-## mcpchecker view
+## mcpchecker result view
 
 Pretty-print evaluation results from a JSON file
 
 ### Synopsis
 
-Render the JSON output produced by "mcpchecker run" in a human-friendly format.
+Render the JSON output produced by "mcpchecker check" in a human-friendly format.
 
 Examples:
-  mcpchecker view mcpchecker-netedge-selector-mismatch-out.json
-  mcpchecker view --task netedge-selector-mismatch --max-events 15 results.json
+  mcpchecker result view mcpchecker-netedge-selector-mismatch-out.json
+  mcpchecker result view --task netedge-selector-mismatch --max-events 15 results.json
 
 ```
-mcpchecker view <results-file> [flags]
+mcpchecker result view <results-file> [flags]
 ```
 
 ### Options
@@ -27,5 +27,5 @@ mcpchecker view <results-file> [flags]
 
 ### SEE ALSO
 
-* [mcpchecker](mcpchecker.md)	 - MCP evaluation framework
+* [mcpchecker result](mcpchecker_result.md)	 - Commands for inspecting and analyzing evaluation result files
 

--- a/docs/reference/output-format.md
+++ b/docs/reference/output-format.md
@@ -41,16 +41,16 @@ Use the CLI to inspect results:
 
 ```bash
 # Pretty-print results
-mcpchecker view mcpchecker-my-eval-out.json
+mcpchecker result view mcpchecker-my-eval-out.json
 
 # Show a compact summary
-mcpchecker summary mcpchecker-my-eval-out.json
+mcpchecker result summary mcpchecker-my-eval-out.json
 
 # Compare two runs
-mcpchecker diff run1-out.json run2-out.json
+mcpchecker result diff run1-out.json run2-out.json
 
 # Verify results meet thresholds
-mcpchecker verify mcpchecker-my-eval-out.json
+mcpchecker result verify mcpchecker-my-eval-out.json
 ```
 
 See the [CLI reference](cli/mcpchecker.md) for full details on each command.

--- a/pkg/cli/diff.go
+++ b/pkg/cli/diff.go
@@ -47,8 +47,8 @@ Shows regressions, improvements, new tasks, removed tasks, and overall pass rate
 Useful for posting on pull requests to show impact of changes.
 
 Example:
-  mcpchecker diff --base results-main.json --current results-pr.json
-  mcpchecker diff --base results-main.json --current results-pr.json --output markdown`,
+  mcpchecker result diff --base results-main.json --current results-pr.json
+  mcpchecker result diff --base results-main.json --current results-pr.json --output markdown`,
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/result.go
+++ b/pkg/cli/result.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewResultCmd creates the result parent command
+func NewResultCmd() *cobra.Command {
+	resultCmd := &cobra.Command{
+		Use:   "result",
+		Short: "Commands for inspecting and analyzing evaluation result files",
+		Long: `Commands for inspecting and analyzing evaluation result files.
+
+These commands operate on the JSON result files produced by 'mcpchecker check'.`,
+	}
+
+	resultCmd.AddCommand(NewViewCmd())
+	resultCmd.AddCommand(NewVerifyCmd())
+	resultCmd.AddCommand(NewSummaryCmd())
+	resultCmd.AddCommand(NewDiffCmd())
+
+	return resultCmd
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -16,10 +16,7 @@ It runs agents through defined tasks and validates their behavior using assertio
 
 	// Add subcommands
 	rootCmd.AddCommand(NewEvalCmd())
-	rootCmd.AddCommand(NewViewCmd())
-	rootCmd.AddCommand(NewVerifyCmd())
-	rootCmd.AddCommand(NewSummaryCmd())
-	rootCmd.AddCommand(NewDiffCmd())
+	rootCmd.AddCommand(NewResultCmd())
 	rootCmd.AddCommand(NewVersionCmd())
 
 	return rootCmd

--- a/pkg/cli/verify.go
+++ b/pkg/cli/verify.go
@@ -21,7 +21,7 @@ func NewVerifyCmd() *cobra.Command {
 Useful as a CI gate to enforce quality standards.
 
 Exits with code 0 if all thresholds are met, code 1 otherwise.
-Use 'mcpchecker summary' to view detailed results.`,
+Use 'mcpchecker result summary' to view detailed results.`,
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/pkg/cli/view.go
+++ b/pkg/cli/view.go
@@ -37,11 +37,11 @@ func NewViewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "view <results-file>",
 		Short: "Pretty-print evaluation results from a JSON file",
-		Long: `Render the JSON output produced by "mcpchecker run" in a human-friendly format.
+		Long: `Render the JSON output produced by "mcpchecker check" in a human-friendly format.
 
 Examples:
-  mcpchecker view mcpchecker-netedge-selector-mismatch-out.json
-  mcpchecker view --task netedge-selector-mismatch --max-events 15 results.json`,
+  mcpchecker result view mcpchecker-netedge-selector-mismatch-out.json
+  mcpchecker result view --task netedge-selector-mismatch --max-events 15 results.json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			evalResults, err := results.Load(args[0])


### PR DESCRIPTION
Fixes #220 

Note: this is a breaking change in the CLI!

As part of cleanup and prep for future commands that operate on the results of a eval run, this PR organizes the commands into a `result` command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized CLI commands under a new `mcpchecker result` command group. Commands like `diff`, `summary`, `verify`, and `view` are now accessed via `mcpchecker result <command>` instead of direct invocation.

* **Documentation**
  * Updated CLI reference documentation to reflect the new command structure.

* **Chores**
  * Updated GitHub Actions workflows to use the new command syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->