### PR TITLE
feat(steps): add support for {agent.output} in templates

### DIFF
--- a/pkg/steps/agent_resolver.go
+++ b/pkg/steps/agent_resolver.go
@@ -1,0 +1,33 @@
+package steps
+
+import "fmt"
+
+// AgentResolver resolves {agent.output} and {agent.prompt} template variables.
+// It returns an error if the agent context has not been set yet (i.e. the step
+// is running before the agent phase).
+type AgentResolver struct {
+	agent *AgentContext
+}
+
+// NewAgentResolver creates a resolver for agent template variables.
+// agent may be nil; Resolve will return an error in that case.
+func NewAgentResolver(agent *AgentContext) *AgentResolver {
+	return &AgentResolver{agent: agent}
+}
+
+// Resolve returns the value for an agent template variable.
+// Supported fields: "output" and "prompt".
+func (r *AgentResolver) Resolve(fieldName string) (string, error) {
+	if r.agent == nil {
+		return "", fmt.Errorf("agent context is not available: agent has not run yet")
+	}
+
+	switch fieldName {
+	case "output":
+		return r.agent.Output, nil
+	case "prompt":
+		return r.agent.Prompt, nil
+	default:
+		return "", fmt.Errorf("unknown agent field %q: supported fields are \"output\" and \"prompt\"", fieldName)
+	}
+}

--- a/pkg/steps/agent_resolver_test.go
+++ b/pkg/steps/agent_resolver_test.go
@@ -1,0 +1,66 @@
+package steps
+
+import (
+	"testing"
+)
+
+func TestAgentResolver(t *testing.T) {
+	tests := []struct {
+		name      string
+		agent     *AgentContext
+		field     string
+		want      string
+		expectErr bool
+	}{
+		{
+			name:  "resolve output",
+			agent: &AgentContext{Prompt: "do something", Output: "I did it"},
+			field: "output",
+			want:  "I did it",
+		},
+		{
+			name:  "resolve prompt",
+			agent: &AgentContext{Prompt: "do something", Output: "I did it"},
+			field: "prompt",
+			want:  "do something",
+		},
+		{
+			name:      "nil agent context",
+			agent:     nil,
+			field:     "output",
+			expectErr: true,
+		},
+		{
+			name:      "unknown field",
+			agent:     &AgentContext{Prompt: "p", Output: "o"},
+			field:     "unknown",
+			expectErr: true,
+		},
+		{
+			name:  "empty output returns empty string",
+			agent: &AgentContext{Prompt: "p", Output: ""},
+			field: "output",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := NewAgentResolver(tt.agent)
+			got, err := resolver.Resolve(tt.field)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Resolve(%q) expected error, got nil", tt.field)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Resolve(%q) unexpected error = %v", tt.field, err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Resolve(%q) = %q, want %q", tt.field, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/steps/http.go
+++ b/pkg/steps/http.go
@@ -75,6 +75,7 @@ func NewHttpStep(cfg *HttpStepConfig) (*HttpStep, error) {
 
 	sources := map[string]template.SourceFactory{
 		"random": template.NewSourceFactory("random"),
+		"agent":  template.NewSourceFactory("agent"),
 	}
 	parseOpts := template.TemplateParserOptions{Sources: sources}
 
@@ -138,6 +139,13 @@ func (s *HttpStep) Execute(ctx context.Context, input *StepInput) (*StepOutput, 
 		for _, h := range s.Headers {
 			h.SetSourceResolver("random", input.Random)
 		}
+	}
+
+	agentResolver := NewAgentResolver(input.Agent)
+	s.URL.SetSourceResolver("agent", agentResolver)
+	s.Method.SetSourceResolver("agent", agentResolver)
+	for _, h := range s.Headers {
+		h.SetSourceResolver("agent", agentResolver)
 	}
 
 	for k, v := range input.Env {

--- a/pkg/steps/llm_judge.go
+++ b/pkg/steps/llm_judge.go
@@ -43,6 +43,7 @@ func NewLLMJudgeStep(cfg *llmjudge.LLMJudgeStepConfig) (*LLMJudgeStep, error) {
 	sources := map[string]template.SourceFactory{
 		"steps":  template.NewSourceFactory("steps"),
 		"random": template.NewSourceFactory("random"),
+		"agent":  template.NewSourceFactory("agent"),
 	}
 
 	// Parse Contains field as template if present
@@ -98,14 +99,17 @@ func (s *LLMJudgeStep) Execute(ctx context.Context, input *StepInput) (*StepOutp
 	}
 
 	resolver := NewStepOutputResolver(stepOutputs)
+	agentResolver := NewAgentResolver(input.Agent)
 	if s.containsTemplate != nil {
 		s.containsTemplate.SetSourceResolver("steps", resolver)
+		s.containsTemplate.SetSourceResolver("agent", agentResolver)
 		if input.Random != nil {
 			s.containsTemplate.SetSourceResolver("random", input.Random)
 		}
 	}
 	if s.exactTemplate != nil {
 		s.exactTemplate.SetSourceResolver("steps", resolver)
+		s.exactTemplate.SetSourceResolver("agent", agentResolver)
 		if input.Random != nil {
 			s.exactTemplate.SetSourceResolver("random", input.Random)
 		}


### PR DESCRIPTION
Part of #254 

This PR adds support for the agent output being within templates.

As a follow up I will be adding env support for the script step, so users can wire the template into env vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for resolving agent-related template variables in HTTP steps and LLM Judge steps, enabling the use of agent output and prompt values within templates.

* **Tests**
  * Added comprehensive test coverage for agent variable resolution functionality, including successful resolution, error handling for unsupported fields, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->