### PR TITLE
feat(steps): wire env through to script steps

### DIFF
--- a/pkg/steps/extension.go
+++ b/pkg/steps/extension.go
@@ -86,7 +86,6 @@ func (r *extensionStep) Execute(ctx context.Context, input *StepInput) (*StepOut
 		Args:      r.args,
 		Context: extprotocol.ExecuteContext{
 			Workdir: input.Workdir,
-			Env:     input.Env,
 		},
 	}
 

--- a/pkg/steps/http.go
+++ b/pkg/steps/http.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -147,18 +146,6 @@ func (s *HttpStep) Execute(ctx context.Context, input *StepInput) (*StepOutput, 
 	for _, h := range s.Headers {
 		h.SetSourceResolver("agent", agentResolver)
 	}
-
-	for k, v := range input.Env {
-		err := os.Setenv(k, v)
-		if err != nil {
-			return nil, fmt.Errorf("failed to set env var '%s' to value '%s': %w", k, v, err)
-		}
-	}
-	defer func() {
-		for k := range input.Env {
-			_ = os.Unsetenv(k)
-		}
-	}()
 
 	method, err := s.Method.GetResult()
 	if err != nil {

--- a/pkg/steps/http_test.go
+++ b/pkg/steps/http_test.go
@@ -460,7 +460,7 @@ func TestHttpStep_Execute(t *testing.T) {
 				Body:   &HttpBody{Raw: ptr.To("")},
 				Expect: &HttpExpect{Status: 200},
 			},
-			input: &StepInput{Env: map[string]string{}},
+			input: &StepInput{},
 			expected: &StepOutput{
 				Type:    "http",
 				Success: true,
@@ -485,7 +485,7 @@ func TestHttpStep_Execute(t *testing.T) {
 				Body:   &HttpBody{JSON: map[string]any{"name": "test"}},
 				Expect: &HttpExpect{Status: 201},
 			},
-			input: &StepInput{Env: map[string]string{}},
+			input: &StepInput{},
 			expected: &StepOutput{
 				Type:    "http",
 				Success: true,
@@ -502,7 +502,7 @@ func TestHttpStep_Execute(t *testing.T) {
 				Body:   &HttpBody{Raw: ptr.To("")},
 				Expect: &HttpExpect{Status: 200},
 			},
-			input: &StepInput{Env: map[string]string{}},
+			input: &StepInput{},
 			expected: &StepOutput{
 				Type:    "http",
 				Success: false,

--- a/pkg/steps/script.go
+++ b/pkg/steps/script.go
@@ -9,20 +9,24 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/genmcp/gen-mcp/pkg/template"
 )
 
 // TODO: Add template support for File and Inline fields once we figure out
 // how to handle escaping conflicts between template syntax and shell escapes.
 type ScriptStepConfig struct {
-	File            string `json:"file,omitempty"`
-	Inline          string `json:"inline,omitempty"`
-	Timeout         string `json:"timeout,omitempty"`
-	ContinueOnError bool   `json:"continueOnError,omitempty"`
+	File            string            `json:"file,omitempty"`
+	Inline          string            `json:"inline,omitempty"`
+	Env             map[string]string `json:"env,omitempty"`
+	Timeout         string            `json:"timeout,omitempty"`
+	ContinueOnError bool              `json:"continueOnError,omitempty"`
 }
 
 type ScriptStep struct {
 	File            string
 	Inline          string
+	Env             map[string]*template.TemplateBuilder
 	Timeout         time.Duration
 	ContinueOnError bool
 }
@@ -45,9 +49,30 @@ func NewScriptStep(cfg *ScriptStepConfig) (*ScriptStep, error) {
 		return nil, err
 	}
 
+	sources := map[string]template.SourceFactory{
+		"agent":  template.NewSourceFactory("agent"),
+		"steps":  template.NewSourceFactory("steps"),
+		"random": template.NewSourceFactory("random"),
+	}
+	parseOpts := template.TemplateParserOptions{Sources: sources}
+
+	env := make(map[string]*template.TemplateBuilder, len(cfg.Env))
+	for k, v := range cfg.Env {
+		parsed, err := template.ParseTemplate(v, parseOpts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse env var %q template: %w", k, err)
+		}
+		builder, err := template.NewTemplateBuilder(parsed, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create template builder for env var %q: %w", k, err)
+		}
+		env[k] = builder
+	}
+
 	step := &ScriptStep{
 		File:            cfg.File,
 		Inline:          cfg.Inline,
+		Env:             env,
 		ContinueOnError: cfg.ContinueOnError,
 	}
 
@@ -65,18 +90,6 @@ func NewScriptStep(cfg *ScriptStepConfig) (*ScriptStep, error) {
 }
 
 func (s *ScriptStep) Execute(ctx context.Context, input *StepInput) (*StepOutput, error) {
-	for k, v := range input.Env {
-		err := os.Setenv(k, v)
-		if err != nil {
-			return nil, fmt.Errorf("failed to set env var '%s' to value '%s': %w", k, v, err)
-		}
-	}
-	defer func() {
-		for k := range input.Env {
-			_ = os.Unsetenv(k)
-		}
-	}()
-
 	ctx, cancel := context.WithTimeout(ctx, s.Timeout)
 	defer cancel()
 
@@ -91,6 +104,13 @@ func (s *ScriptStep) Execute(ctx context.Context, input *StepInput) (*StepOutput
 	if err != nil {
 		return s.handleError(err)
 	}
+
+	resolvedEnv, err := s.resolveEnv(input)
+	if err != nil {
+		return s.handleError(fmt.Errorf("failed to resolve env templates: %w", err))
+	}
+
+	applyEnv(cmd, resolvedEnv)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -203,6 +223,58 @@ func (cfg *ScriptStepConfig) Validate() error {
 	}
 
 	return nil
+}
+
+// resolveEnv resolves template variables in env values using the step input's
+// sources (step outputs, random values, and environment variables).
+func (s *ScriptStep) resolveEnv(input *StepInput) (map[string]string, error) {
+	if len(s.Env) == 0 {
+		return nil, nil
+	}
+
+	stepOutputs := input.StepOutputs
+	if stepOutputs == nil {
+		stepOutputs = make(map[string]map[string]string)
+	}
+
+	resolver := NewStepOutputResolver(stepOutputs)
+	agentResolver := NewAgentResolver(input.Agent)
+
+	resolved := make(map[string]string, len(s.Env))
+	for k, builder := range s.Env {
+		builder.SetSourceResolver("steps", resolver)
+		builder.SetSourceResolver("agent", agentResolver)
+		if input.Random != nil {
+			builder.SetSourceResolver("random", input.Random)
+		}
+
+		result, err := builder.GetResult()
+		if err != nil {
+			return nil, fmt.Errorf("env var %q: %w", k, err)
+		}
+
+		str, ok := result.(string)
+		if !ok {
+			return nil, fmt.Errorf("env var %q resolved to non-string type: %T", k, result)
+		}
+
+		resolved[k] = str
+	}
+
+	return resolved, nil
+}
+
+// applyEnv sets additional environment variables on the command,
+// inheriting the current process environment as a base.
+func applyEnv(cmd *exec.Cmd, env map[string]string) {
+	if len(env) == 0 {
+		return
+	}
+
+	cmd.Env = os.Environ()
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
 }
 
 func getShell() string {

--- a/pkg/steps/script_test.go
+++ b/pkg/steps/script_test.go
@@ -106,7 +106,7 @@ func TestScriptStep_Execute(t *testing.T) {
 			config: &ScriptStepConfig{
 				Inline: "echo hello",
 			},
-			input: &StepInput{Env: map[string]string{}},
+			input: &StepInput{},
 			expected: &StepOutput{
 				Success: true,
 				Message: "hello\n",
@@ -117,21 +117,51 @@ func TestScriptStep_Execute(t *testing.T) {
 			config: &ScriptStepConfig{
 				Inline: "#!/bin/sh\necho shebang",
 			},
-			input: &StepInput{Env: map[string]string{}},
+			input: &StepInput{},
 			expected: &StepOutput{
 				Success: true,
 				Message: "shebang\n",
 			},
 			expectErr: false,
 		},
-		"inline script uses env vars": {
+		"inline script uses env vars from config": {
 			config: &ScriptStepConfig{
 				Inline: "echo $TEST_VAR",
+				Env:    map[string]string{"TEST_VAR": "from_config"},
 			},
-			input: &StepInput{Env: map[string]string{"TEST_VAR": "from_env"}},
+			input: &StepInput{},
 			expected: &StepOutput{
 				Success: true,
-				Message: "from_env\n",
+				Message: "from_config\n",
+			},
+			expectErr: false,
+		},
+		"env resolves step output template": {
+			config: &ScriptStepConfig{
+				Inline: "echo $MY_VAR",
+				Env:    map[string]string{"MY_VAR": "{steps.setup.value}"},
+			},
+			input: &StepInput{
+				StepOutputs: map[string]map[string]string{
+					"setup": {"value": "resolved_output"},
+				},
+			},
+			expected: &StepOutput{
+				Success: true,
+				Message: "resolved_output\n",
+			},
+			expectErr: false,
+		},
+		"env resolves random template": {
+			config: &ScriptStepConfig{
+				Inline: "echo $MY_ID",
+				Env:    map[string]string{"MY_ID": "{random.id}"},
+			},
+			input: &StepInput{
+				Random: NewRandomResolver(),
+			},
+			expected: &StepOutput{
+				Success: true,
 			},
 			expectErr: false,
 		},
@@ -139,7 +169,7 @@ func TestScriptStep_Execute(t *testing.T) {
 			config: &ScriptStepConfig{
 				Inline: "exit 1",
 			},
-			input:     &StepInput{Env: map[string]string{}},
+			input:     &StepInput{},
 			expectErr: true,
 		},
 		"inline script fails with continueOnError": {
@@ -147,7 +177,7 @@ func TestScriptStep_Execute(t *testing.T) {
 				Inline:          "exit 1",
 				ContinueOnError: true,
 			},
-			input: &StepInput{Env: map[string]string{}},
+			input: &StepInput{},
 			expected: &StepOutput{
 				Success: false,
 			},
@@ -195,7 +225,7 @@ func TestScriptStep_Execute_File(t *testing.T) {
 			config: &ScriptStepConfig{
 				File: scriptPath,
 			},
-			input: &StepInput{Env: map[string]string{}},
+			input: &StepInput{},
 			expected: &StepOutput{
 				Success: true,
 				Message: "file_script\n",
@@ -207,7 +237,6 @@ func TestScriptStep_Execute_File(t *testing.T) {
 				File: "test.sh",
 			},
 			input: &StepInput{
-				Env:     map[string]string{},
 				Workdir: tmpDir,
 			},
 			expected: &StepOutput{
@@ -220,7 +249,7 @@ func TestScriptStep_Execute_File(t *testing.T) {
 			config: &ScriptStepConfig{
 				File: "/nonexistent/script.sh",
 			},
-			input:     &StepInput{Env: map[string]string{}},
+			input:     &StepInput{},
 			expectErr: true,
 		},
 	}

--- a/pkg/steps/step.go
+++ b/pkg/steps/step.go
@@ -24,7 +24,6 @@ type StepRunner interface {
 }
 
 type StepInput struct {
-	Env         map[string]string
 	Workdir     string
 	Agent       *AgentContext
 	StepOutputs map[string]map[string]string // Maps step type to its outputs


### PR DESCRIPTION
Resolves #254 

Note: this requires #277 to merge + a rebase on top of that

This PR adds support for setting env vars in script steps, as well as using templates for those env vars

It also cleans up the `StepInput` type which had an unused/not user settable `Env` field present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Scripts now support per-step environment variable configuration with template resolution (referencing outputs from previous steps and random values).

* **Bug Fixes**
  * Removed per-step environment variable handling from HTTP and extension execution paths.

* **Refactor**
  * Environment variable scoping changed from global step input to individual step-level configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->