### PR TITLE
feat(cli): add evaluation summary to output file and console

### DIFF
--- a/docs/reference/output-format.md
+++ b/docs/reference/output-format.md
@@ -22,11 +22,17 @@ The `summary` object captures the resolved configuration used for the evaluation
   "summary": {
     "agent": {
       "type": "builtin.llm-agent",
-      "model": "openai:gpt-5"
+      "name": "my-agent",
+      "model": "openai:gpt-5",
+      "path": "agents/my-agent.yaml",
+      "command": "node agent.js"
     },
     "judge": {
       "type": "builtin.llm-agent",
-      "model": "claude-sonnet-4"
+      "name": "my-judge",
+      "model": "claude-sonnet-4",
+      "path": "agents/my-judge.yaml",
+      "command": "node judge.js"
     },
     "mcpServers": [
       {

--- a/docs/reference/output-format.md
+++ b/docs/reference/output-format.md
@@ -1,12 +1,67 @@
 # Output Format
 
-mcpchecker saves evaluation results to `mcpchecker-<eval-name>-out.json`. This file contains the full record of each task run, including pass/fail status, assertion results, and call history.
+mcpchecker saves evaluation results to `mcpchecker-<eval-name>-out.json`. This file contains the resolved configuration summary and the full record of each task run, including pass/fail status, assertion results, and call history.
 
-## Result Structure
+## Top-Level Structure
+
+The output file is a JSON object with two top-level fields:
+
+```json
+{
+  "summary": { ... },
+  "results": [ ... ]
+}
+```
+
+### Summary
+
+The `summary` object captures the resolved configuration used for the evaluation run. This makes the output self-documenting — you can always tell which agent, model, judge, and MCP servers were used.
+
+```json
+{
+  "summary": {
+    "agent": {
+      "type": "builtin.llm-agent",
+      "model": "openai:gpt-5"
+    },
+    "judge": {
+      "type": "builtin.llm-agent",
+      "model": "claude-sonnet-4"
+    },
+    "mcpServers": [
+      {
+        "name": "kubernetes",
+        "type": "http",
+        "url": "http://localhost:8080/mcp"
+      }
+    ],
+    "evals": {
+      "names": ["create-pod", "list-pods", "delete-pod"],
+      "taskSets": [
+        {
+          "glob": "../tasks/kubernetes/*.yaml",
+          "labelSelector": { "suite": "kubernetes" }
+        }
+      ]
+    },
+    "timeout": {
+      "defaultTask": "5m"
+    },
+    "parallelWorkers": 1,
+    "runs": 1
+  },
+  "results": [ ... ]
+}
+```
+
+### Results
+
+The `results` array contains one entry per task run. Each entry has the following structure:
 
 ```json
 {
   "taskName": "create-nginx-pod",
+  "taskPath": "tasks/kubernetes/create-pod.yaml",
   "taskPassed": true,
   "allAssertionsPassed": true,
   "assertionResults": {
@@ -24,6 +79,8 @@ mcpchecker saves evaluation results to `mcpchecker-<eval-name>-out.json`. This f
   }
 }
 ```
+
+> **Legacy format:** Older output files (pre-summary) used a bare JSON array at the top level. All CLI commands (`view`, `summary`, `diff`, `verify`) auto-detect and support both formats.
 
 ## Interpreting Results
 

--- a/docs/reference/output-format.md
+++ b/docs/reference/output-format.md
@@ -80,7 +80,7 @@ The `results` array contains one entry per task run. Each entry has the followin
 }
 ```
 
-> **Legacy format:** Older output files (pre-summary) used a bare JSON array at the top level. All CLI commands (`view`, `summary`, `diff`, `verify`) auto-detect and support both formats.
+> **Legacy format:** Older output files (pre-summary) used a bare JSON array at the top level. All CLI commands (`view`, `summary`, `diff`, `verify`) auto-detect and support both formats. Support for the legacy format is deprecated and will be removed in a future release — re-run evaluations to generate output in the current format.
 
 ## Interpreting Results
 

--- a/functional/testcase/generators.go
+++ b/functional/testcase/generators.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mcpchecker/mcpchecker/functional/servers/agent"
 	"github.com/mcpchecker/mcpchecker/pkg/eval"
+	"github.com/mcpchecker/mcpchecker/pkg/results"
 	"github.com/mcpchecker/mcpchecker/pkg/task"
 	"github.com/mcpchecker/mcpchecker/pkg/util"
 )
@@ -200,19 +201,11 @@ func (g *Generator) writeJSON(filename string, data any) (string, error) {
 	return path, nil
 }
 
-// ReadEvalResults reads and parses the eval output JSON file
+// ReadEvalResults reads and parses the eval output JSON file.
+// Supports both the current format (object with summary + results) and
+// the legacy format (bare array of results).
 func ReadEvalResults(path string) ([]*eval.EvalResult, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	var results []*eval.EvalResult
-	if err := json.Unmarshal(data, &results); err != nil {
-		return nil, err
-	}
-
-	return results, nil
+	return results.Load(path)
 }
 
 // WriteFile writes content to a file in the temp directory

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -261,7 +261,7 @@ func (d *progressDisplay) handleProgress(event eval.ProgressEvent) {
 
 func (d *progressDisplay) printSummary(s *eval.EvalSummary) {
 	fmt.Println()
-	d.bold.Println("=== Evaluation Summary ===")
+	d.bold.Println("=== Evaluation Configuration Summary ===")
 
 	if s.Agent != nil {
 		fmt.Printf("Agent:          %s\n", s.Agent.Type)

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -269,7 +269,7 @@ func (d *progressDisplay) printSummary(s *eval.EvalSummary) {
 			fmt.Printf("Agent Name:     %s\n", s.Agent.Name)
 		}
 		if s.Agent.Model != "" {
-			fmt.Printf("Model:          %s\n", s.Agent.Model)
+			fmt.Printf("Agent Model:    %s\n", s.Agent.Model)
 		}
 		if s.Agent.Path != "" {
 			fmt.Printf("Agent Path:     %s\n", s.Agent.Path)

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -93,14 +93,14 @@ func NewEvalCmd() *cobra.Command {
 			// Run with progress
 			ctx := context.Background()
 			ctx = util.WithVerbose(ctx, verbose)
-			results, err := runner.RunWithProgress(ctx, run, display.handleProgress)
+			output, err := runner.RunWithProgress(ctx, run, display.handleProgress)
 			if err != nil {
 				return fmt.Errorf("eval failed: %w", err)
 			}
 
-			// Save results to JSON file
+			// Save results to JSON file (includes summary metadata)
 			outputFile := fmt.Sprintf("mcpchecker-%s-out.json", spec.Metadata.Name)
-			if err := saveResultsToFile(results, outputFile); err != nil {
+			if err := saveOutputToFile(output, outputFile); err != nil {
 				return fmt.Errorf("failed to save results to file: %w", err)
 			}
 			if outputFormat == "text" {
@@ -108,7 +108,7 @@ func NewEvalCmd() *cobra.Command {
 			}
 
 			// Display results
-			if err := displayResults(results, outputFormat); err != nil {
+			if err := displayResults(output, outputFormat); err != nil {
 				return fmt.Errorf("failed to display results: %w", err)
 			}
 
@@ -176,6 +176,9 @@ func (d *progressDisplay) handleProgress(event eval.ProgressEvent) {
 	switch event.Type {
 	case eval.EventEvalStart:
 		d.bold.Println("\n=== Starting Evaluation ===")
+		if event.Summary != nil {
+			d.printSummary(event.Summary)
+		}
 
 	case eval.EventTaskStart:
 		fmt.Println()
@@ -256,15 +259,80 @@ func (d *progressDisplay) handleProgress(event eval.ProgressEvent) {
 	}
 }
 
-func displayResults(results []*eval.EvalResult, format string) error {
+func (d *progressDisplay) printSummary(s *eval.EvalSummary) {
+	fmt.Println()
+	d.bold.Println("=== Evaluation Summary ===")
+
+	if s.Agent != nil {
+		fmt.Printf("Agent:          %s\n", s.Agent.Type)
+		if s.Agent.Model != "" {
+			fmt.Printf("Model:          %s\n", s.Agent.Model)
+		}
+	}
+
+	if s.Judge != nil {
+		fmt.Printf("Judge LLM:      %s\n", s.Judge.Model)
+	}
+
+	for _, srv := range s.MCPServers {
+		if srv.URL != "" {
+			fmt.Printf("MCP Server:     %s: %s\n", srv.Name, srv.URL)
+		} else if srv.Command != "" {
+			fmt.Printf("MCP Server:     %s: %s (stdio)\n", srv.Name, srv.Command)
+		}
+	}
+
+	if s.Evals != nil {
+		fmt.Printf("Evals:          %d matched", len(s.Evals.Names))
+		if len(s.Evals.Names) > 0 && len(s.Evals.Names) <= 10 {
+			fmt.Printf(" (%s)", strings.Join(s.Evals.Names, ", "))
+		}
+		fmt.Println()
+
+		for _, ts := range s.Evals.TaskSets {
+			if ts.Glob != "" {
+				fmt.Printf("  Glob:           %s\n", ts.Glob)
+			} else if ts.Path != "" {
+				fmt.Printf("  Path:           %s\n", ts.Path)
+			}
+			for k, v := range ts.LabelSelector {
+				fmt.Printf("  Label Selector: %s=%s\n", k, v)
+			}
+		}
+	}
+
+	if s.Timeout != nil {
+		if s.Timeout.Task != "" {
+			fmt.Printf("Timeout:        %s (per task, override)\n", s.Timeout.Task)
+		} else if s.Timeout.DefaultTask != "" {
+			fmt.Printf("Timeout:        %s (per task)\n", s.Timeout.DefaultTask)
+		}
+		if s.Timeout.Cleanup != "" {
+			fmt.Printf("Cleanup:        %s (override)\n", s.Timeout.Cleanup)
+		} else if s.Timeout.DefaultCleanup != "" {
+			fmt.Printf("Cleanup:        %s\n", s.Timeout.DefaultCleanup)
+		}
+	}
+
+	if s.ParallelWorkers > 1 {
+		fmt.Printf("Parallel:       %d workers\n", s.ParallelWorkers)
+	}
+	if s.Runs > 1 {
+		fmt.Printf("Runs:           %d per task\n", s.Runs)
+	}
+
+	d.bold.Println("===============================")
+}
+
+func displayResults(output *eval.EvalOutput, format string) error {
 	switch format {
 	case "json":
 		encoder := json.NewEncoder(os.Stdout)
 		encoder.SetIndent("", "  ")
-		return encoder.Encode(results)
+		return encoder.Encode(output)
 
 	case "text":
-		return displayTextResults(results)
+		return displayTextResults(output.Results)
 
 	default:
 		return fmt.Errorf("unknown output format: %s", format)
@@ -532,7 +600,7 @@ func printSingleAssertion(name string, result *eval.SingleAssertionResult) {
 	}
 }
 
-func saveResultsToFile(results []*eval.EvalResult, filename string) error {
+func saveOutputToFile(output *eval.EvalOutput, filename string) error {
 	file, err := os.Create(filename)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
@@ -541,7 +609,7 @@ func saveResultsToFile(results []*eval.EvalResult, filename string) error {
 
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ")
-	if err := encoder.Encode(results); err != nil {
+	if err := encoder.Encode(output); err != nil {
 		return fmt.Errorf("failed to encode results: %w", err)
 	}
 

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -265,13 +265,36 @@ func (d *progressDisplay) printSummary(s *eval.EvalSummary) {
 
 	if s.Agent != nil {
 		fmt.Printf("Agent:          %s\n", s.Agent.Type)
+		if s.Agent.Name != "" {
+			fmt.Printf("Agent Name:     %s\n", s.Agent.Name)
+		}
 		if s.Agent.Model != "" {
 			fmt.Printf("Model:          %s\n", s.Agent.Model)
+		}
+		if s.Agent.Path != "" {
+			fmt.Printf("Agent Path:     %s\n", s.Agent.Path)
+		}
+		if s.Agent.Command != "" {
+			fmt.Printf("Agent Command:  %s\n", s.Agent.Command)
 		}
 	}
 
 	if s.Judge != nil {
-		fmt.Printf("Judge LLM:      %s\n", s.Judge.Model)
+		if s.Judge.Type != "" {
+			fmt.Printf("Judge:          %s\n", s.Judge.Type)
+		}
+		if s.Judge.Name != "" {
+			fmt.Printf("Judge Name:     %s\n", s.Judge.Name)
+		}
+		if s.Judge.Model != "" {
+			fmt.Printf("Judge Model:    %s\n", s.Judge.Model)
+		}
+		if s.Judge.Path != "" {
+			fmt.Printf("Judge Path:     %s\n", s.Judge.Path)
+		}
+		if s.Judge.Command != "" {
+			fmt.Printf("Judge Command:  %s\n", s.Judge.Command)
+		}
 	}
 
 	for _, srv := range s.MCPServers {

--- a/pkg/eval/output.go
+++ b/pkg/eval/output.go
@@ -22,14 +22,20 @@ type EvalSummary struct {
 
 // AgentSummary describes the agent configuration.
 type AgentSummary struct {
-	Type  string `json:"type"`
-	Model string `json:"model,omitempty"`
+	Type    string `json:"type"`
+	Name    string `json:"name,omitempty"`
+	Model   string `json:"model,omitempty"`
+	Path    string `json:"path,omitempty"`
+	Command string `json:"command,omitempty"`
 }
 
 // JudgeSummary describes the LLM judge configuration.
 type JudgeSummary struct {
-	Type  string `json:"type,omitempty"`
-	Model string `json:"model,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Model   string `json:"model,omitempty"`
+	Path    string `json:"path,omitempty"`
+	Command string `json:"command,omitempty"`
 }
 
 // MCPServerSummary describes a single MCP server.

--- a/pkg/eval/output.go
+++ b/pkg/eval/output.go
@@ -1,0 +1,78 @@
+package eval
+
+import "net/url"
+
+// EvalOutput wraps evaluation results with configuration summary metadata.
+// This is the top-level structure written to the JSON output file.
+type EvalOutput struct {
+	Summary *EvalSummary `json:"summary"`
+	Results []*EvalResult `json:"results"`
+}
+
+// EvalSummary captures the resolved configuration used for an evaluation run.
+type EvalSummary struct {
+	Agent           *AgentSummary      `json:"agent"`
+	Judge           *JudgeSummary      `json:"judge,omitempty"`
+	MCPServers      []MCPServerSummary `json:"mcpServers,omitempty"`
+	Evals           *EvalsSummary      `json:"evals"`
+	Timeout         *TimeoutSummary    `json:"timeout,omitempty"`
+	ParallelWorkers int                `json:"parallelWorkers"`
+	Runs            int                `json:"runs"`
+}
+
+// AgentSummary describes the agent configuration.
+type AgentSummary struct {
+	Type  string `json:"type"`
+	Model string `json:"model,omitempty"`
+}
+
+// JudgeSummary describes the LLM judge configuration.
+type JudgeSummary struct {
+	Type  string `json:"type,omitempty"`
+	Model string `json:"model,omitempty"`
+}
+
+// MCPServerSummary describes a single MCP server.
+type MCPServerSummary struct {
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	URL     string `json:"url,omitempty"`
+	Command string `json:"command,omitempty"`
+}
+
+// EvalsSummary describes the matched evaluations.
+type EvalsSummary struct {
+	Names    []string         `json:"names"`
+	TaskSets []TaskSetSummary `json:"taskSets,omitempty"`
+}
+
+// TaskSetSummary describes a single task set configuration.
+type TaskSetSummary struct {
+	Glob          string            `json:"glob,omitempty"`
+	Path          string            `json:"path,omitempty"`
+	LabelSelector map[string]string `json:"labelSelector,omitempty"`
+}
+
+// TimeoutSummary describes the timeout configuration.
+type TimeoutSummary struct {
+	DefaultTask    string `json:"defaultTask,omitempty"`
+	Task           string `json:"task,omitempty"`
+	DefaultCleanup string `json:"defaultCleanup,omitempty"`
+	Cleanup        string `json:"cleanup,omitempty"`
+}
+
+// sanitizeURL strips query parameters and userinfo from a URL to avoid
+// leaking credentials (tokens, passwords) into output files.
+func sanitizeURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	parsed.User = nil
+	return parsed.String()
+}

--- a/pkg/eval/output_test.go
+++ b/pkg/eval/output_test.go
@@ -1,0 +1,61 @@
+package eval
+
+import "testing"
+
+func TestSanitizeURL(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "empty string",
+			raw:  "",
+			want: "",
+		},
+		{
+			name: "clean URL",
+			raw:  "http://localhost:8080/mcp",
+			want: "http://localhost:8080/mcp",
+		},
+		{
+			name: "strips query params",
+			raw:  "http://localhost:8080/mcp?token=secret123&debug=true",
+			want: "http://localhost:8080/mcp",
+		},
+		{
+			name: "strips userinfo",
+			raw:  "http://admin:password@localhost:8080/mcp",
+			want: "http://localhost:8080/mcp",
+		},
+		{
+			name: "strips both query and userinfo",
+			raw:  "https://user:pass@example.com/api?key=abc",
+			want: "https://example.com/api",
+		},
+		{
+			name: "strips fragment",
+			raw:  "http://localhost:8080/mcp#section",
+			want: "http://localhost:8080/mcp",
+		},
+		{
+			name: "preserves path",
+			raw:  "http://localhost:8080/v1/mcp/endpoint",
+			want: "http://localhost:8080/v1/mcp/endpoint",
+		},
+		{
+			name: "preserves port",
+			raw:  "http://localhost:9090/mcp",
+			want: "http://localhost:9090/mcp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeURL(tt.raw)
+			if got != tt.want {
+				t.Errorf("sanitizeURL(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/eval/progress.go
+++ b/pkg/eval/progress.go
@@ -9,7 +9,8 @@ type ProgressCallback func(event ProgressEvent)
 type ProgressEvent struct {
 	Type    ProgressEventType
 	Message string
-	Task    *EvalResult // Populated for task-related events
+	Task    *EvalResult  // Populated for task-related events
+	Summary *EvalSummary // Populated for EventEvalStart
 }
 
 // ProgressEventType represents the type of progress event

--- a/pkg/eval/runner.go
+++ b/pkg/eval/runner.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -54,8 +55,8 @@ type EvalResult struct {
 }
 
 type EvalRunner interface {
-	Run(ctx context.Context, taskPattern string) ([]*EvalResult, error)
-	RunWithProgress(ctx context.Context, taskPattern string, callback ProgressCallback) ([]*EvalResult, error)
+	Run(ctx context.Context, taskPattern string) (*EvalOutput, error)
+	RunWithProgress(ctx context.Context, taskPattern string, callback ProgressCallback) (*EvalOutput, error)
 }
 
 // RunnerOptions configures the eval runner behavior
@@ -161,11 +162,11 @@ func (r *evalRunner) loadAgentSpec() (*agent.AgentSpec, error) {
 	return agent.ResolveAgentRef(r.spec.Config.Agent)
 }
 
-func (r *evalRunner) Run(ctx context.Context, taskPattern string) ([]*EvalResult, error) {
+func (r *evalRunner) Run(ctx context.Context, taskPattern string) (*EvalOutput, error) {
 	return r.RunWithProgress(ctx, taskPattern, NoopProgressCallback)
 }
 
-func (r *evalRunner) RunWithProgress(ctx context.Context, taskPattern string, callback ProgressCallback) ([]*EvalResult, error) {
+func (r *evalRunner) RunWithProgress(ctx context.Context, taskPattern string, callback ProgressCallback) (*EvalOutput, error) {
 	r.progressCallback = callback
 
 	if taskPattern == "" {
@@ -176,11 +177,6 @@ func (r *evalRunner) RunWithProgress(ctx context.Context, taskPattern string, ca
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile regexp for task name match: %w", err)
 	}
-
-	r.progressCallback(ProgressEvent{
-		Type:    EventEvalStart,
-		Message: "Starting evaluation",
-	})
 
 	mcpConfig, err := r.loadMcpConfig()
 	if err != nil {
@@ -214,6 +210,15 @@ func (r *evalRunner) RunWithProgress(ctx context.Context, taskPattern string, ca
 		return nil, err
 	}
 
+	// Build summary from resolved configuration
+	summary := r.buildSummary(mcpConfig, judge, taskConfigs)
+
+	r.progressCallback(ProgressEvent{
+		Type:    EventEvalStart,
+		Message: "Starting evaluation",
+		Summary: summary,
+	})
+
 	// Group tasks by parallel support
 	groups := groupTasksByParallelSupport(taskConfigs)
 
@@ -235,7 +240,99 @@ func (r *evalRunner) RunWithProgress(ctx context.Context, taskPattern string, ca
 		Message: "Evaluation complete",
 	})
 
-	return results, nil
+	return &EvalOutput{
+		Summary: summary,
+		Results: results,
+	}, nil
+}
+
+func (r *evalRunner) buildSummary(mcpConfig *mcpclient.MCPConfig, judge llmjudge.LLMJudge, taskConfigs []taskConfig) *EvalSummary {
+	summary := &EvalSummary{
+		ParallelWorkers: r.parallelWorkers,
+		Runs:            r.runs,
+	}
+
+	// Agent
+	if r.spec.Config.Agent != nil {
+		summary.Agent = &AgentSummary{
+			Type:  r.spec.Config.Agent.Type,
+			Model: r.spec.Config.Agent.Model,
+		}
+	}
+
+	// Judge
+	if modelName := judge.ModelName(); modelName != "" && modelName != "noop" {
+		judgeSummary := &JudgeSummary{Model: modelName}
+		if r.spec.Config.LLMJudge != nil && r.spec.Config.LLMJudge.AgentRef != nil {
+			judgeSummary.Type = r.spec.Config.LLMJudge.AgentRef.Type
+		}
+		summary.Judge = judgeSummary
+	}
+
+	// MCP servers (sorted by name for deterministic output)
+	if mcpConfig != nil {
+		servers := mcpConfig.GetEnabledServers()
+		names := make([]string, 0, len(servers))
+		for name := range servers {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+
+		for _, name := range names {
+			server := servers[name]
+			serverType := "stdio"
+			if server.IsHttp() {
+				serverType = "http"
+			}
+			summary.MCPServers = append(summary.MCPServers, MCPServerSummary{
+				Name:    name,
+				Type:    serverType,
+				URL:     sanitizeURL(server.URL),
+				Command: server.Command,
+			})
+		}
+	}
+
+	// Task sets from config
+	var taskSetSummaries []TaskSetSummary
+	for _, ts := range r.spec.Config.TaskSets {
+		taskSetSummaries = append(taskSetSummaries, TaskSetSummary{
+			Glob:          ts.Glob,
+			Path:          ts.Path,
+			LabelSelector: ts.LabelSelector,
+		})
+	}
+
+	// Matched task names
+	taskNames := make([]string, 0, len(taskConfigs))
+	for _, tc := range taskConfigs {
+		taskNames = append(taskNames, tc.spec.Metadata.Name)
+	}
+	summary.Evals = &EvalsSummary{
+		Names:    taskNames,
+		TaskSets: taskSetSummaries,
+	}
+
+	// Timeouts
+	timeout := &TimeoutSummary{
+		Task:           r.taskTimeout,
+		DefaultTask:    r.defaultTaskTimeout,
+		Cleanup:        r.cleanupTimeout,
+		DefaultCleanup: r.defaultCleanupTimeout,
+	}
+	if r.spec.Config.DefaultTaskLimits != nil && r.spec.Config.DefaultTaskLimits.Timeout != "" {
+		if timeout.DefaultTask == "" {
+			timeout.DefaultTask = r.spec.Config.DefaultTaskLimits.Timeout
+		}
+		if timeout.DefaultCleanup == "" && r.spec.Config.DefaultTaskLimits.CleanupTimeout != "" {
+			timeout.DefaultCleanup = r.spec.Config.DefaultTaskLimits.CleanupTimeout
+		}
+	}
+	if timeout.Task != "" || timeout.DefaultTask != "" || timeout.Cleanup != "" || timeout.DefaultCleanup != "" {
+		summary.Timeout = timeout
+	}
+
+	return summary
 }
 
 func (r *evalRunner) collectTaskConfigs(rx *regexp.Regexp) ([]taskConfig, error) {

--- a/pkg/eval/runner.go
+++ b/pkg/eval/runner.go
@@ -211,7 +211,7 @@ func (r *evalRunner) RunWithProgress(ctx context.Context, taskPattern string, ca
 	}
 
 	// Build summary from resolved configuration
-	summary := r.buildSummary(mcpConfig, judge, taskConfigs)
+	summary := r.buildSummary(agentSpec, mcpConfig, judge, taskConfigs)
 
 	r.progressCallback(ProgressEvent{
 		Type:    EventEvalStart,
@@ -246,25 +246,48 @@ func (r *evalRunner) RunWithProgress(ctx context.Context, taskPattern string, ca
 	}, nil
 }
 
-func (r *evalRunner) buildSummary(mcpConfig *mcpclient.MCPConfig, judge llmjudge.LLMJudge, taskConfigs []taskConfig) *EvalSummary {
+func (r *evalRunner) buildSummary(agentSpec *agent.AgentSpec, mcpConfig *mcpclient.MCPConfig, judge llmjudge.LLMJudge, taskConfigs []taskConfig) *EvalSummary {
 	summary := &EvalSummary{
 		ParallelWorkers: r.parallelWorkers,
 		Runs:            r.runs,
 	}
 
-	// Agent
+	// Agent — include ref-level info plus resolved spec details
 	if r.spec.Config.Agent != nil {
-		summary.Agent = &AgentSummary{
+		agentSummary := &AgentSummary{
 			Type:  r.spec.Config.Agent.Type,
 			Model: r.spec.Config.Agent.Model,
+			Path:  r.spec.Config.Agent.Path,
 		}
+		if agentSpec != nil {
+			agentSummary.Name = agentSpec.Metadata.Name
+			if agentSummary.Model == "" && agentSpec.Builtin != nil {
+				agentSummary.Model = agentSpec.Builtin.Model
+			}
+			if agentSpec.AcpConfig != nil {
+				agentSummary.Command = agentSpec.AcpConfig.Cmd
+			}
+		}
+		summary.Agent = agentSummary
 	}
 
 	// Judge
 	if modelName := judge.ModelName(); modelName != "" && modelName != "noop" {
 		judgeSummary := &JudgeSummary{Model: modelName}
 		if r.spec.Config.LLMJudge != nil && r.spec.Config.LLMJudge.AgentRef != nil {
-			judgeSummary.Type = r.spec.Config.LLMJudge.AgentRef.Type
+			ref := r.spec.Config.LLMJudge.AgentRef
+			judgeSummary.Type = ref.Type
+			judgeSummary.Path = ref.Path
+			// Resolve spec for additional details (name, ACP command)
+			if judgeSpec, err := agent.ResolveAgentRef(ref); err == nil && judgeSpec != nil {
+				judgeSummary.Name = judgeSpec.Metadata.Name
+				if judgeSummary.Model == "" && judgeSpec.Builtin != nil {
+					judgeSummary.Model = judgeSpec.Builtin.Model
+				}
+				if judgeSpec.AcpConfig != nil {
+					judgeSummary.Command = judgeSpec.AcpConfig.Cmd
+				}
+			}
 		}
 		summary.Judge = judgeSummary
 	}
@@ -320,8 +343,8 @@ func (r *evalRunner) buildSummary(mcpConfig *mcpclient.MCPConfig, judge llmjudge
 		Cleanup:        r.cleanupTimeout,
 		DefaultCleanup: r.defaultCleanupTimeout,
 	}
-	if r.spec.Config.DefaultTaskLimits != nil && r.spec.Config.DefaultTaskLimits.Timeout != "" {
-		if timeout.DefaultTask == "" {
+	if r.spec.Config.DefaultTaskLimits != nil {
+		if timeout.DefaultTask == "" && r.spec.Config.DefaultTaskLimits.Timeout != "" {
 			timeout.DefaultTask = r.spec.Config.DefaultTaskLimits.Timeout
 		}
 		if timeout.DefaultCleanup == "" && r.spec.Config.DefaultTaskLimits.CleanupTimeout != "" {

--- a/pkg/results/results.go
+++ b/pkg/results/results.go
@@ -2,6 +2,7 @@
 package results
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -25,18 +26,55 @@ type Stats struct {
 }
 
 // Load reads a JSON results file and returns the parsed evaluations.
+// Supports both the current format (object with summary + results) and
+// the legacy format (bare array of results).
 func Load(path string) ([]*eval.EvalResult, error) {
+	output, err := LoadOutput(path)
+	if err != nil {
+		return nil, err
+	}
+	return output.Results, nil
+}
+
+// LoadOutput reads a JSON results file and returns the full output including summary.
+// Supports both the current format (object with summary + results) and
+// the legacy format (bare array of results).
+func LoadOutput(path string) (*eval.EvalOutput, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read results file: %w", err)
 	}
 
-	var results []*eval.EvalResult
-	if err := json.Unmarshal(data, &results); err != nil {
-		return nil, fmt.Errorf("failed to parse results JSON: %w", err)
+	return ParseOutput(data)
+}
+
+// ParseOutput parses JSON data as an EvalOutput.
+// Auto-detects legacy array format vs current object format.
+func ParseOutput(data []byte) (*eval.EvalOutput, error) {
+	// Trim whitespace to detect format
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("empty results data")
 	}
 
-	return results, nil
+	// Legacy format: bare JSON array
+	if trimmed[0] == '[' {
+		var results []*eval.EvalResult
+		if err := json.Unmarshal(data, &results); err != nil {
+			return nil, fmt.Errorf("failed to parse results JSON: %w", err)
+		}
+		return &eval.EvalOutput{Results: results}, nil
+	}
+
+	// Current format: object with summary + results
+	var output eval.EvalOutput
+	if err := json.Unmarshal(data, &output); err != nil {
+		return nil, fmt.Errorf("failed to parse results JSON: %w", err)
+	}
+	if output.Results == nil {
+		return nil, fmt.Errorf("invalid results file: missing 'results' field")
+	}
+	return &output, nil
 }
 
 // Filter returns the subset of results whose task names contain the filter substring.

--- a/pkg/results/results_test.go
+++ b/pkg/results/results_test.go
@@ -179,6 +179,125 @@ func TestFilter(t *testing.T) {
 	}
 }
 
+func TestParseOutput(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantResults int
+		wantSummary bool
+		wantErr     bool
+	}{
+		{
+			name:        "new object format",
+			input:       `{"summary":{"agent":{"type":"builtin.llm-agent"},"parallelWorkers":1,"runs":1},"results":[{"taskName":"t1","taskPassed":true}]}`,
+			wantResults: 1,
+			wantSummary: true,
+		},
+		{
+			name:        "legacy array format",
+			input:       `[{"taskName":"t1","taskPassed":true},{"taskName":"t2","taskPassed":false}]`,
+			wantResults: 2,
+			wantSummary: false,
+		},
+		{
+			name:        "new format with empty results array",
+			input:       `{"summary":{"parallelWorkers":1,"runs":1},"results":[]}`,
+			wantResults: 0,
+			wantSummary: true,
+		},
+		{
+			name:    "empty input",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only",
+			input:   "   \n  ",
+			wantErr: true,
+		},
+		{
+			name:    "object missing results field",
+			input:   `{"summary":{"parallelWorkers":1}}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON",
+			input:   `{broken`,
+			wantErr: true,
+		},
+		{
+			name:        "legacy empty array",
+			input:       `[]`,
+			wantResults: 0,
+			wantSummary: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := ParseOutput([]byte(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(output.Results) != tt.wantResults {
+				t.Errorf("got %d results, want %d", len(output.Results), tt.wantResults)
+			}
+			if tt.wantSummary && output.Summary == nil {
+				t.Error("expected summary, got nil")
+			}
+			if !tt.wantSummary && output.Summary != nil {
+				t.Error("expected no summary, got one")
+			}
+		})
+	}
+}
+
+func TestLoadOutput(t *testing.T) {
+	// Write new format file and verify LoadOutput reads it correctly
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "output.json")
+
+	data := `{"summary":{"agent":{"type":"builtin.llm-agent","model":"openai:gpt-4"},"parallelWorkers":2,"runs":1},"results":[{"taskName":"task-1","taskPassed":true}]}`
+	if err := os.WriteFile(filePath, []byte(data), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	output, err := LoadOutput(filePath)
+	if err != nil {
+		t.Fatalf("LoadOutput failed: %v", err)
+	}
+
+	if output.Summary == nil || output.Summary.Agent == nil {
+		t.Fatal("expected summary with agent")
+	}
+	if output.Summary.Agent.Model != "openai:gpt-4" {
+		t.Errorf("agent model = %s, want openai:gpt-4", output.Summary.Agent.Model)
+	}
+	if len(output.Results) != 1 {
+		t.Errorf("got %d results, want 1", len(output.Results))
+	}
+}
+
+func TestLoadBackwardCompat(t *testing.T) {
+	// Load using legacy format through results.Load (returns []*EvalResult)
+	evalResults := sampleResults()
+	filePath := createTestResultsFile(t, evalResults)
+
+	loaded, err := Load(filePath)
+	if err != nil {
+		t.Fatalf("Load failed on legacy format: %v", err)
+	}
+	if len(loaded) != 3 {
+		t.Errorf("got %d results, want 3", len(loaded))
+	}
+}
+
 func TestCollectFailedAssertions(t *testing.T) {
 	assertionResults := &eval.CompositeAssertionResult{
 		ToolsUsed:    &eval.SingleAssertionResult{Passed: false, Reason: "Tool not called"},


### PR DESCRIPTION
Fixes: #265 

Embed resolved configuration (agent, judge, MCP servers, matched evals, timeouts) in a top-level summary object in the JSON output

Changes:
- Output format changes from bare array to {summary, results}
- Auto-detect legacy array vs new object format
- Align -o json stdout format with file format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluation output now includes a top-level configuration summary (agent/judge, servers, eval selection, timeouts, parallel/runs) alongside results; summary is shown during runs.

* **Documentation**
  * Output format docs updated to describe the new object-based JSON with summary+results and note legacy array format (legacy auto-detected; deprecated).

* **Enhancements**
  * CLI/tools auto-detect and support both current and legacy output formats.

* **Tests**
  * Added tests for output parsing and URL sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->