### PR TITLE
feat(cli): support multiple label selectors with OR semantics

### DIFF
--- a/docs/reference/cli/mcpchecker_check.md
+++ b/docs/reference/cli/mcpchecker_check.md
@@ -17,7 +17,7 @@ mcpchecker check [eval-config-file] [flags]
       --default-cleanup-timeout string   Default cleanup timeout for tasks without their own (e.g., '2m')
       --default-task-timeout string      Default timeout for tasks without their own (e.g., '15m', '1h')
   -h, --help                             help for check
-  -l, --label-selector string            Filter taskSets by label (format: key=value, e.g., suite=kubernetes)
+  -l, --label-selector string            Filter taskSets by labels (e.g., suite=k8s,suite=helm for OR; suite=k8s,difficulty=easy for AND)
       --mcp-config-file string           Path to MCP config file (overrides value in eval config)
   -o, --output string                    Output format (text, json) (default "text")
   -p, --parallel int                     Number of parallel workers for tasks marked as parallel (1 = sequential) (default 1)

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -125,7 +125,7 @@ func NewEvalCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Output format (text, json)")
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
 	cmd.Flags().StringVarP(&run, "run", "r", "", "Regular expression to match task names to run (unanchored, like go test -run)")
-	cmd.Flags().StringVarP(&labelSelector, "label-selector", "l", "", "Filter taskSets by label (format: key=value, e.g., suite=kubernetes)")
+	cmd.Flags().StringVarP(&labelSelector, "label-selector", "l", "", "Filter taskSets by labels (e.g., suite=k8s,suite=helm for OR; suite=k8s,difficulty=easy for AND)")
 	cmd.Flags().IntVarP(&parallelWorkers, "parallel", "p", 1, "Number of parallel workers for tasks marked as parallel (1 = sequential)")
 	cmd.Flags().IntVarP(&runs, "runs", "n", 1, "Number of times to run each task (for consistency testing)")
 	cmd.Flags().StringVar(&mcpConfigFile, "mcp-config-file", "", "Path to MCP config file (overrides value in eval config)")

--- a/pkg/eval/label_selector.go
+++ b/pkg/eval/label_selector.go
@@ -5,8 +5,50 @@ import (
 	"strings"
 )
 
-// ApplyLabelSelectorFilter applies a CLI-provided label selector (format: key=value)
-// to an EvalSpec by merging it into each taskSet's LabelSelector (AND semantics).
+// ParseLabelSelector parses a comma-separated label selector string into a multi-value map.
+// Format: "key1=value1,key2=value2,key1=value3".
+// Different keys use AND semantics; duplicate keys use OR semantics.
+// Example: "suite=kubernetes,suite=helm,difficulty=easy" means
+// (suite=kubernetes OR suite=helm) AND difficulty=easy.
+func ParseLabelSelector(selector string) (map[string][]string, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		return nil, nil
+	}
+
+	labels := make(map[string][]string)
+	for _, pair := range strings.Split(selector, ",") {
+		parts := strings.SplitN(strings.TrimSpace(pair), "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid label selector format, expected key=value, got: %s", pair)
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if key == "" || value == "" {
+			return nil, fmt.Errorf("label selector key and value cannot be empty")
+		}
+		labels[key] = appendUnique(labels[key], value)
+	}
+
+	return labels, nil
+}
+
+func appendUnique(slice []string, val string) []string {
+	for _, s := range slice {
+		if s == val {
+			return slice
+		}
+	}
+	return append(slice, val)
+}
+
+// ApplyLabelSelectorFilter applies a CLI-provided label selector to an EvalSpec
+// by merging it into each taskSet's LabelSelector.
+// Different keys use AND semantics; duplicate keys use OR semantics.
+// Example: "suite=kubernetes,suite=helm" keeps taskSets matching either suite.
+//
+// For taskSets that don't already have a key set, the taskSet is expanded into
+// one copy per value so that tasks are filtered correctly at the task level.
 //
 // This is intentionally kept in the eval package so filtering logic is consolidated
 // outside of the CLI layer.
@@ -14,44 +56,92 @@ func ApplyLabelSelectorFilter(spec *EvalSpec, selector string) error {
 	if spec == nil {
 		return fmt.Errorf("eval spec cannot be nil")
 	}
-	if selector == "" {
+
+	labels, err := ParseLabelSelector(selector)
+	if err != nil {
+		return err
+	}
+	if len(labels) == 0 {
 		return nil
 	}
 
-	// Parse label selector (format: key=value)
-	parts := strings.SplitN(selector, "=", 2)
-	if len(parts) != 2 {
-		return fmt.Errorf("invalid label selector format, expected key=value, got: %s", selector)
-	}
-	key := strings.TrimSpace(parts[0])
-	value := strings.TrimSpace(parts[1])
-
-	if key == "" || value == "" {
-		return fmt.Errorf("label selector key and value cannot be empty")
-	}
-
-	// Filter taskSets that match the label selector
 	var filteredTaskSets []TaskSet
 	for _, ts := range spec.Config.TaskSets {
-		// Merge CLI selector into taskSet selector (AND semantics)
 		if ts.LabelSelector == nil {
 			ts.LabelSelector = make(map[string]string)
 		}
-		if existing, exists := ts.LabelSelector[key]; exists && existing != value {
-			continue // incompatible selector
+
+		// Check compatibility: if the taskSet already has a value for a key,
+		// it must be one of the requested values.
+		compatible := true
+		for key, values := range labels {
+			if existing, exists := ts.LabelSelector[key]; exists {
+				if !containsValue(values, existing) {
+					compatible = false
+					break
+				}
+			}
 		}
-		ts.LabelSelector[key] = value
-		filteredTaskSets = append(filteredTaskSets, ts)
+		if !compatible {
+			continue
+		}
+
+		// Expand: for keys not already set on the taskSet, create a copy per value.
+		expanded := expandTaskSet(ts, labels)
+		filteredTaskSets = append(filteredTaskSets, expanded...)
 	}
 
 	if len(filteredTaskSets) == 0 {
-		return fmt.Errorf("no taskSets match label selector %s=%s", key, value)
+		return fmt.Errorf("no taskSets match label selector: %s", selector)
 	}
 
-	// Replace taskSets with filtered ones
 	spec.Config.TaskSets = filteredTaskSets
 
 	return nil
+}
+
+// expandTaskSet creates copies of a taskSet for each combination of unset label values.
+// Keys already present on the taskSet are left as-is.
+func expandTaskSet(ts TaskSet, labels map[string][]string) []TaskSet {
+	result := []TaskSet{ts}
+
+	for key, values := range labels {
+		if _, exists := ts.LabelSelector[key]; exists {
+			// Already set — no expansion needed for this key
+			continue
+		}
+
+		// Expand current result set: for each existing copy, create one per value
+		var expanded []TaskSet
+		for _, r := range result {
+			for _, val := range values {
+				copy := copyTaskSet(r)
+				copy.LabelSelector[key] = val
+				expanded = append(expanded, copy)
+			}
+		}
+		result = expanded
+	}
+
+	return result
+}
+
+func copyTaskSet(ts TaskSet) TaskSet {
+	newSelector := make(map[string]string, len(ts.LabelSelector))
+	for k, v := range ts.LabelSelector {
+		newSelector[k] = v
+	}
+	ts.LabelSelector = newSelector
+	return ts
+}
+
+func containsValue(values []string, target string) bool {
+	for _, v := range values {
+		if v == target {
+			return true
+		}
+	}
+	return false
 }
 
 // matchesLabelSelector checks if the task labels match the label selector.

--- a/pkg/eval/label_selector_test.go
+++ b/pkg/eval/label_selector_test.go
@@ -1,0 +1,169 @@
+package eval
+
+import (
+	"testing"
+)
+
+func TestParseLabelSelector(t *testing.T) {
+	tests := []struct {
+		name    string
+		selector string
+		want    map[string][]string
+		wantErr bool
+	}{
+		{"empty string", "", nil, false},
+		{"single label", "suite=kubernetes", map[string][]string{"suite": {"kubernetes"}}, false},
+		{"different keys (AND)", "suite=kubernetes,difficulty=easy", map[string][]string{"suite": {"kubernetes"}, "difficulty": {"easy"}}, false},
+		{"same key multiple values (OR)", "suite=kubernetes,suite=helm", map[string][]string{"suite": {"kubernetes", "helm"}}, false},
+		{"mixed AND and OR", "suite=kubernetes,suite=helm,difficulty=easy", map[string][]string{"suite": {"kubernetes", "helm"}, "difficulty": {"easy"}}, false},
+		{"whitespace around pairs", " suite=kubernetes , suite=helm ", map[string][]string{"suite": {"kubernetes", "helm"}}, false},
+		{"duplicate same value deduped", "suite=kubernetes,suite=kubernetes", map[string][]string{"suite": {"kubernetes"}}, false},
+		{"missing value", "suite", nil, true},
+		{"empty key", "=value", nil, true},
+		{"empty value", "suite=", nil, true},
+		{"value with equals", "key=val=ue", map[string][]string{"key": {"val=ue"}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseLabelSelector(tt.selector)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseLabelSelector(%q) error = %v, wantErr %v", tt.selector, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if len(got) != len(tt.want) {
+					t.Errorf("ParseLabelSelector(%q) = %v, want %v", tt.selector, got, tt.want)
+					return
+				}
+				for k, wantVals := range tt.want {
+					gotVals := got[k]
+					if len(gotVals) != len(wantVals) {
+						t.Errorf("ParseLabelSelector(%q)[%q] = %v, want %v", tt.selector, k, gotVals, wantVals)
+						continue
+					}
+					for i, v := range wantVals {
+						if gotVals[i] != v {
+							t.Errorf("ParseLabelSelector(%q)[%q][%d] = %q, want %q", tt.selector, k, i, gotVals[i], v)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestApplyLabelSelectorFilter(t *testing.T) {
+	makeSpec := func(taskSets ...TaskSet) *EvalSpec {
+		return &EvalSpec{
+			Config: EvalConfig{
+				TaskSets: taskSets,
+			},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		spec         *EvalSpec
+		selector     string
+		wantTaskSets int
+		wantErr      bool
+	}{
+		{
+			name:    "nil spec",
+			spec:    nil,
+			selector: "suite=k8s",
+			wantErr: true,
+		},
+		{
+			name:         "empty selector",
+			spec:         makeSpec(TaskSet{}),
+			selector:     "",
+			wantTaskSets: 1,
+		},
+		{
+			name: "single label matches one",
+			spec: makeSpec(
+				TaskSet{LabelSelector: map[string]string{"suite": "k8s"}},
+				TaskSet{LabelSelector: map[string]string{"suite": "helm"}},
+			),
+			selector:     "suite=k8s",
+			wantTaskSets: 1,
+		},
+		{
+			name: "OR on same key matches multiple taskSets",
+			spec: makeSpec(
+				TaskSet{LabelSelector: map[string]string{"suite": "k8s"}},
+				TaskSet{LabelSelector: map[string]string{"suite": "helm"}},
+				TaskSet{LabelSelector: map[string]string{"suite": "istio"}},
+			),
+			selector:     "suite=k8s,suite=helm",
+			wantTaskSets: 2,
+		},
+		{
+			name: "AND across keys narrows results",
+			spec: makeSpec(
+				TaskSet{LabelSelector: map[string]string{"suite": "k8s", "difficulty": "easy"}},
+				TaskSet{LabelSelector: map[string]string{"suite": "k8s", "difficulty": "hard"}},
+				TaskSet{LabelSelector: map[string]string{"suite": "helm"}},
+			),
+			selector:     "suite=k8s,difficulty=easy",
+			wantTaskSets: 1,
+		},
+		{
+			name: "OR and AND combined",
+			spec: makeSpec(
+				TaskSet{LabelSelector: map[string]string{"suite": "k8s", "difficulty": "easy"}},
+				TaskSet{LabelSelector: map[string]string{"suite": "helm", "difficulty": "easy"}},
+				TaskSet{LabelSelector: map[string]string{"suite": "istio", "difficulty": "easy"}},
+			),
+			selector:     "suite=k8s,suite=helm,difficulty=easy",
+			wantTaskSets: 2,
+		},
+		{
+			name: "no matches",
+			spec: makeSpec(
+				TaskSet{LabelSelector: map[string]string{"suite": "helm"}},
+			),
+			selector: "suite=k8s",
+			wantErr:  true,
+		},
+		{
+			name: "taskSet without labels expands for single value",
+			spec: makeSpec(
+				TaskSet{},
+			),
+			selector:     "suite=k8s",
+			wantTaskSets: 1,
+		},
+		{
+			name: "taskSet without labels expands for OR values",
+			spec: makeSpec(
+				TaskSet{},
+			),
+			selector:     "suite=k8s,suite=helm",
+			wantTaskSets: 2,
+		},
+		{
+			name:     "invalid selector format",
+			spec:     makeSpec(TaskSet{}),
+			selector: "invalid",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ApplyLabelSelectorFilter(tt.spec, tt.selector)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ApplyLabelSelectorFilter() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.spec != nil {
+				if len(tt.spec.Config.TaskSets) != tt.wantTaskSets {
+					t.Errorf("got %d taskSets, want %d", len(tt.spec.Config.TaskSets), tt.wantTaskSets)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes: #288 

Allow the --label-selector flag to accept duplicate keys for OR matching (e.g., suite=k8s,suite=helm) while different keys retain AND semantics. 

for example: 
```
mcpchecker check eval.yaml -l "suite=kubernetes,suite=helm"
```
will run both suites 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced label selector filtering to support multiple labels with AND/OR semantics: comma-separated `key=value` pairs where repeated keys represent OR (e.g., `suite=k8s,suite=helm`) and different keys represent AND (e.g., `suite=k8s,difficulty=easy`).

* **Documentation**
  * Updated CLI option documentation to describe the enhanced multi-label selection syntax.

* **Tests**
  * Added comprehensive test coverage for label selector parsing and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->