### PR TITLE
feat(cli): Added support to convert result to JUnit format.

### DIFF
--- a/pkg/cli/convert.go
+++ b/pkg/cli/convert.go
@@ -1,0 +1,18 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewConvertCmd creates the convert parent command
+func NewConvertCmd() *cobra.Command {
+	convertCmd := &cobra.Command{
+		Use:   "convert",
+		Short: "Commands for converting evaluation result files",
+		Long:  `Commands for converting evaluation result files into other formats or reports.`,
+	}
+
+	convertCmd.AddCommand(NewJUnitCmd())
+
+	return convertCmd
+}

--- a/pkg/cli/junit.go
+++ b/pkg/cli/junit.go
@@ -1,0 +1,250 @@
+package cli
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/mcpchecker/mcpchecker/pkg/eval"
+	"github.com/mcpchecker/mcpchecker/pkg/results"
+	"github.com/mcpchecker/mcpchecker/pkg/task"
+	"github.com/spf13/cobra"
+)
+
+// JUnit XML types
+
+type junitTestSuites struct {
+	XMLName    xml.Name         `xml:"testsuites"`
+	TestSuites []junitTestSuite `xml:"testsuite"`
+}
+
+type junitTestSuite struct {
+	Name     string          `xml:"name,attr"`
+	Tests    int             `xml:"tests,attr"`
+	Failures int             `xml:"failures,attr"`
+	Errors   int             `xml:"errors,attr"`
+	Cases    []junitTestCase `xml:"testcase"`
+}
+
+type junitTestCase struct {
+	Name      string        `xml:"name,attr"`
+	Classname string        `xml:"classname,attr"`
+	Failure   *junitFailure `xml:"failure,omitempty"`
+	Error     *junitError   `xml:"error,omitempty"`
+	SystemOut string        `xml:"system-out,omitempty"`
+}
+
+type junitFailure struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr"`
+	Body    string `xml:",chardata"`
+}
+
+type junitError struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr"`
+	Body    string `xml:",chardata"`
+}
+
+// NewJUnitCmd creates the junit command for converting eval results to JUnit XML.
+func NewJUnitCmd() *cobra.Command {
+	var (
+		taskFilter string
+		outputFile string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "junit <results-file>",
+		Short: "Convert evaluation results to JUnit XML",
+		Long: `Convert the JSON output produced by "mcpchecker check" into JUnit XML,
+suitable for CI/CD tools like Jenkins and GitLab.
+
+Example:
+  mcpchecker result junit results.json
+  mcpchecker result junit --output-file junit-report.xml results.json`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			evalResults, err := results.Load(args[0])
+			if err != nil {
+				return err
+			}
+
+			filtered := results.Filter(evalResults, taskFilter)
+			if len(filtered) == 0 {
+				if taskFilter == "" {
+					return errors.New("no tasks found in results")
+				}
+				return fmt.Errorf("no tasks matched filter %q", taskFilter)
+			}
+
+			opts := viewOptions{
+				showTimeline:   true,
+				maxEvents:      defaultMaxEvents,
+				maxOutputLines: defaultMaxOutputLines,
+				maxLineLength:  defaultMaxLineLength,
+			}
+			data, err := convertJUnit(filtered, opts)
+			if err != nil {
+				return err
+			}
+
+			if outputFile != "" {
+				if err := os.WriteFile(outputFile, data, 0o644); err != nil {
+					return fmt.Errorf("failed to write output file %q: %w", outputFile, err)
+				}
+			} else {
+				_, err = cmd.OutOrStdout().Write(data)
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&taskFilter, "task", "", "Only convert results for tasks whose name contains this value")
+	cmd.Flags().StringVar(&outputFile, "output-file", "", "Write output to a file instead of stdout")
+	return cmd
+}
+
+// convertJUnit converts eval results to JUnit XML format.
+func convertJUnit(evalResults []*eval.EvalResult, opts viewOptions) ([]byte, error) {
+	suite := buildJUnitSuite(evalResults, opts)
+	suites := junitTestSuites{TestSuites: []junitTestSuite{suite}}
+
+	output, err := xml.MarshalIndent(suites, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal JUnit XML: %w", err)
+	}
+	return append([]byte(xml.Header), output...), nil
+}
+
+// buildJUnitSuite converts eval results into a single JUnit test suite.
+func buildJUnitSuite(evalResults []*eval.EvalResult, opts viewOptions) junitTestSuite {
+	suite := junitTestSuite{
+		Name:  "mcpchecker",
+		Tests: len(evalResults),
+		Cases: make([]junitTestCase, 0, len(evalResults)),
+	}
+
+	for _, result := range evalResults {
+		tc := junitTestCase{
+			Name:      result.TaskName,
+			Classname: extractJUnitClassname(result.TaskPath),
+			SystemOut: renderEvalResult(result, opts),
+		}
+
+		switch {
+		case !result.TaskPassed:
+			// Execution error (agent error, timeout, verification failure)
+			suite.Errors++
+			msg := result.TaskError
+			errType := "ExecutionError"
+			if result.AgentExecutionError {
+				errType = "AgentExecutionError"
+			} else if result.TimedOut {
+				errType = "Timeout"
+			}
+			if msg == "" {
+				msg = errType
+			}
+			tc.Error = &junitError{
+				Message: sanitizeXMLString(truncateString(msg, 200)),
+				Type:    errType,
+				Body:    sanitizeXMLString(msg),
+			}
+
+		case result.TaskPassed && !result.AllAssertionsPassed:
+			// Assertion failure
+			suite.Failures++
+			var failureDetails []string
+			if result.AssertionResults != nil {
+				failureDetails = results.CollectFailedAssertions(result.AssertionResults)
+			}
+			msg := strings.Join(failureDetails, "; ")
+			if msg == "" {
+				msg = "Assertions failed"
+			}
+			tc.Failure = &junitFailure{
+				Message: sanitizeXMLString(truncateString(msg, 200)),
+				Type:    "AssertionFailure",
+				Body:    sanitizeXMLString(strings.Join(failureDetails, "\n")),
+			}
+		}
+
+		suite.Cases = append(suite.Cases, tc)
+	}
+
+	return suite
+}
+
+// renderEvalResult renders an eval result using the same format as "result view".
+func renderEvalResult(result *eval.EvalResult, opts viewOptions) string {
+	var buf strings.Builder
+	prev := color.NoColor
+	color.NoColor = true
+	defer func() { color.NoColor = prev }()
+	printEvalResult(&buf, result, opts)
+
+	// Also include output from scripts such as setup, verify and cleanup which may contain useful information about failures.
+	// This is not included in the default "result view" output but can be helpful in CI contexts.
+	containsOutput := func(phase *task.PhaseOutput) bool { return phase != nil && len(phase.Steps) > 0 }
+	if containsOutput(result.SetupOutput) || containsOutput(result.VerifyOutput) || containsOutput(result.CleanupOutput) {
+		fmt.Fprintf(&buf, "Steps output:\n")
+		printPhaseOutput(&buf, "Setup", result.SetupOutput)
+		printPhaseOutput(&buf, "Verify", result.VerifyOutput)
+		printPhaseOutput(&buf, "Cleanup", result.CleanupOutput)
+	}
+
+	return sanitizeXMLString(buf.String())
+}
+
+// printPhaseOutput writes step outputs from a single task phase to w.
+func printPhaseOutput(w io.Writer, label string, phase *task.PhaseOutput) {
+	if phase == nil || len(phase.Steps) == 0 {
+		return
+	}
+	for _, step := range phase.Steps {
+		if step == nil {
+			continue
+		}
+		if step.Message != "" {
+			fmt.Fprintf(w, "--- %s (stdout) ---\n", label)
+			fmt.Fprintf(w, "%s\n", indentBlock(step.Message, "  "))
+		}
+		if step.Error != "" {
+			fmt.Fprintf(w, "--- %s (stderr) ---\n", label)
+			fmt.Fprintf(w, "%s\n", indentBlock(step.Error, "  "))
+		}
+	}
+}
+
+// sanitizeXMLString removes characters that are invalid in XML 1.0 from the input string.
+func sanitizeXMLString(s string) string {
+	isXmlChar := func(r rune) bool {
+		return r == 0x09 || r == 0x0A || r == 0x0D ||
+			(r >= 0x20 && r <= 0xD7FF) ||
+			(r >= 0xE000 && r <= 0xFFFD) ||
+			(r >= 0x10000 && r <= 0x10FFFF)
+	}
+	return strings.Map(func(r rune) rune {
+		if isXmlChar(r) {
+			return r
+		}
+		return -1 // Drop the character
+	}, s)
+}
+
+// extractJUnitClassname derives a classname from the task file path.
+func extractJUnitClassname(taskPath string) string {
+	if taskPath == "" {
+		return ""
+	}
+	// Remove extension and use the path components
+	base := strings.TrimSuffix(taskPath, filepath.Ext(taskPath))
+	return filepath.Base(base)
+}

--- a/pkg/cli/junit_test.go
+++ b/pkg/cli/junit_test.go
@@ -1,0 +1,366 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mcpchecker/mcpchecker/pkg/eval"
+)
+
+func TestJUnitCommand(t *testing.T) {
+	results := sampleResults()
+	filePath := createTestResultsFile(t, results)
+
+	cmd := NewJUnitCmd()
+	cmd.SetArgs([]string{filePath})
+
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("junit command failed: %v", err)
+	}
+}
+
+func TestJUnitCommandWithTaskFilter(t *testing.T) {
+	results := sampleResults()
+	filePath := createTestResultsFile(t, results)
+
+	cmd := NewJUnitCmd()
+	cmd.SetArgs([]string{filePath, "--task", "task-1"})
+
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("junit command with --task filter failed: %v", err)
+	}
+}
+
+func TestJUnitCommandNoTaskMatch(t *testing.T) {
+	results := sampleResults()
+	filePath := createTestResultsFile(t, results)
+
+	cmd := NewJUnitCmd()
+	cmd.SetArgs([]string{filePath, "--task", "nonexistent-task"})
+
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("junit command should fail when no tasks match filter")
+	}
+}
+
+func TestJUnitCommandFileNotFound(t *testing.T) {
+	cmd := NewJUnitCmd()
+	cmd.SetArgs([]string{"/nonexistent/path/results.json"})
+
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("junit command should fail with nonexistent file")
+	}
+}
+
+
+func TestJUnitCommandOutputFile(t *testing.T) {
+	results := sampleResults()
+	filePath := createTestResultsFile(t, results)
+
+	outPath := filepath.Join(t.TempDir(), "report.xml")
+
+	cmd := NewJUnitCmd()
+	cmd.SetArgs([]string{filePath, "--output-file", outPath})
+
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("junit command with --output-file failed: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("failed to read output file: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "<testsuites>") {
+		t.Error("output file should contain JUnit XML")
+	}
+	if !strings.Contains(content, "task-1") {
+		t.Error("output file should contain task names")
+	}
+}
+
+func TestBuildJUnitSuiteAllPassed(t *testing.T) {
+	results := []*eval.EvalResult{
+		{
+			TaskName:            "passed-task",
+			TaskPath:            "/path/to/passed-task.yaml",
+			TaskPassed:          true,
+			AllAssertionsPassed: true,
+			AssertionResults: &eval.CompositeAssertionResult{
+				ToolsUsed: &eval.SingleAssertionResult{Passed: true},
+			},
+		},
+	}
+
+	suite := buildJUnitSuite(results, viewOptions{})
+
+	if suite.Name != "mcpchecker" {
+		t.Errorf("suite.Name = %q, want %q", suite.Name, "mcpchecker")
+	}
+	if suite.Tests != 1 {
+		t.Errorf("suite.Tests = %d, want 1", suite.Tests)
+	}
+	if suite.Failures != 0 {
+		t.Errorf("suite.Failures = %d, want 0", suite.Failures)
+	}
+	if suite.Errors != 0 {
+		t.Errorf("suite.Errors = %d, want 0", suite.Errors)
+	}
+	if suite.Cases[0].Failure != nil {
+		t.Error("passed test case should not have a Failure element")
+	}
+	if suite.Cases[0].Error != nil {
+		t.Error("passed test case should not have an Error element")
+	}
+}
+
+func TestBuildJUnitSuiteWithFailure(t *testing.T) {
+	results := []*eval.EvalResult{
+		{
+			TaskName:            "assertion-failed",
+			TaskPath:            "/path/to/task.yaml",
+			TaskPassed:          true,
+			AllAssertionsPassed: false,
+			AssertionResults: &eval.CompositeAssertionResult{
+				ToolsUsed: &eval.SingleAssertionResult{Passed: false, Reason: "Tool not called"},
+			},
+		},
+	}
+
+	suite := buildJUnitSuite(results, viewOptions{})
+
+	if suite.Failures != 1 {
+		t.Errorf("suite.Failures = %d, want 1", suite.Failures)
+	}
+	if suite.Errors != 0 {
+		t.Errorf("suite.Errors = %d, want 0", suite.Errors)
+	}
+	if suite.Cases[0].Failure == nil {
+		t.Fatal("failed assertion test case should have a Failure element")
+	}
+	if suite.Cases[0].Failure.Type != "AssertionFailure" {
+		t.Errorf("Failure.Type = %q, want %q", suite.Cases[0].Failure.Type, "AssertionFailure")
+	}
+	if !strings.Contains(suite.Cases[0].Failure.Message, "Tool not called") {
+		t.Errorf("Failure.Message should contain assertion reason, got %q", suite.Cases[0].Failure.Message)
+	}
+}
+
+func TestBuildJUnitSuiteWithError(t *testing.T) {
+	results := []*eval.EvalResult{
+		{
+			TaskName:   "exec-error",
+			TaskPath:   "/path/to/task.yaml",
+			TaskPassed: false,
+			TaskError:  "verification failed",
+		},
+	}
+
+	suite := buildJUnitSuite(results, viewOptions{})
+
+	if suite.Failures != 0 {
+		t.Errorf("suite.Failures = %d, want 0", suite.Failures)
+	}
+	if suite.Errors != 1 {
+		t.Errorf("suite.Errors = %d, want 1", suite.Errors)
+	}
+	if suite.Cases[0].Error == nil {
+		t.Fatal("failed test case should have an Error element")
+	}
+	if suite.Cases[0].Error.Type != "ExecutionError" {
+		t.Errorf("Error.Type = %q, want %q", suite.Cases[0].Error.Type, "ExecutionError")
+	}
+	if suite.Cases[0].Error.Body != "verification failed" {
+		t.Errorf("Error.Body = %q, want %q", suite.Cases[0].Error.Body, "verification failed")
+	}
+}
+
+func TestBuildJUnitSuiteAgentExecutionError(t *testing.T) {
+	results := []*eval.EvalResult{
+		{
+			TaskName:            "agent-crash",
+			TaskPath:            "/path/to/task.yaml",
+			TaskPassed:          false,
+			AgentExecutionError: true,
+		},
+	}
+
+	suite := buildJUnitSuite(results, viewOptions{})
+
+	if suite.Cases[0].Error == nil {
+		t.Fatal("agent error test case should have an Error element")
+	}
+	if suite.Cases[0].Error.Type != "AgentExecutionError" {
+		t.Errorf("Error.Type = %q, want %q", suite.Cases[0].Error.Type, "AgentExecutionError")
+	}
+}
+
+func TestBuildJUnitSuiteTimeout(t *testing.T) {
+	results := []*eval.EvalResult{
+		{
+			TaskName:   "timed-out",
+			TaskPath:   "/path/to/task.yaml",
+			TaskPassed: false,
+			TimedOut:   true,
+			TaskError:  "task exceeded timeout",
+		},
+	}
+
+	suite := buildJUnitSuite(results, viewOptions{})
+
+	if suite.Cases[0].Error == nil {
+		t.Fatal("timed out test case should have an Error element")
+	}
+	if suite.Cases[0].Error.Type != "Timeout" {
+		t.Errorf("Error.Type = %q, want %q", suite.Cases[0].Error.Type, "Timeout")
+	}
+}
+
+func TestBuildJUnitSuiteNilAssertionResults(t *testing.T) {
+	results := []*eval.EvalResult{
+		{
+			TaskName:            "nil-assertions",
+			TaskPath:            "/path/to/task.yaml",
+			TaskPassed:          true,
+			AllAssertionsPassed: false,
+			AssertionResults:    nil,
+		},
+	}
+
+	suite := buildJUnitSuite(results, viewOptions{})
+
+	if suite.Failures != 1 {
+		t.Errorf("suite.Failures = %d, want 1", suite.Failures)
+	}
+	if suite.Cases[0].Failure == nil {
+		t.Fatal("test case with nil assertions but AllAssertionsPassed=false should have Failure")
+	}
+	if suite.Cases[0].Failure.Message != "Assertions failed" {
+		t.Errorf("Failure.Message = %q, want %q", suite.Cases[0].Failure.Message, "Assertions failed")
+	}
+}
+
+func TestBuildJUnitSuiteMixedResults(t *testing.T) {
+	results := sampleResults() // 1 passed, 1 assertion failure, 1 execution error
+
+	suite := buildJUnitSuite(results, viewOptions{})
+
+	if suite.Tests != 3 {
+		t.Errorf("suite.Tests = %d, want 3", suite.Tests)
+	}
+	if suite.Failures != 1 {
+		t.Errorf("suite.Failures = %d, want 1", suite.Failures)
+	}
+	if suite.Errors != 1 {
+		t.Errorf("suite.Errors = %d, want 1", suite.Errors)
+	}
+}
+
+func TestBuildJUnitSuiteSystemOut(t *testing.T) {
+	results := []*eval.EvalResult{
+		{
+			TaskName:            "task-with-output",
+			TaskPath:            "/path/to/task.yaml",
+			TaskPassed:          true,
+			Difficulty:          "easy",
+			AllAssertionsPassed: true,
+		},
+	}
+
+	suite := buildJUnitSuite(results, viewOptions{showTimeline: true})
+
+	if suite.Cases[0].SystemOut == "" {
+		t.Error("test case should have system-out content")
+	}
+	if !strings.Contains(suite.Cases[0].SystemOut, "task-with-output") {
+		t.Error("system-out should contain the task name")
+	}
+	if !strings.Contains(suite.Cases[0].SystemOut, "PASSED") {
+		t.Error("system-out should contain the status")
+	}
+}
+
+func TestConvertJUnitXMLStructure(t *testing.T) {
+	results := sampleResults()
+
+	buf, err := convertJUnit(results, viewOptions{})
+	if err != nil {
+		t.Fatalf("convertJUnit failed: %v", err)
+	}
+
+	output := string(buf)
+
+	if !strings.HasPrefix(output, xml.Header) {
+		t.Error("output should start with XML header")
+	}
+	if !strings.Contains(output, "<testsuites>") {
+		t.Error("output should contain <testsuites>")
+	}
+	if !strings.Contains(output, `<testsuite name="mcpchecker"`) {
+		t.Error("output should contain testsuite with name mcpchecker")
+	}
+	if !strings.Contains(output, "<testcase") {
+		t.Error("output should contain <testcase> elements")
+	}
+
+	// Verify it's valid XML by parsing it
+	var suites junitTestSuites
+	xmlContent := output[len(xml.Header):]
+	if err := xml.Unmarshal([]byte(strings.TrimSpace(xmlContent)), &suites); err != nil {
+		t.Fatalf("output is not valid XML: %v", err)
+	}
+
+	if len(suites.TestSuites) != 1 {
+		t.Errorf("expected 1 test suite, got %d", len(suites.TestSuites))
+	}
+	if suites.TestSuites[0].Tests != 3 {
+		t.Errorf("expected 3 tests, got %d", suites.TestSuites[0].Tests)
+	}
+}
+
+func TestExtractJUnitClassname(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"/path/to/task.yaml", "task"},
+		{"/path/to/my-task.yaml", "my-task"},
+		{"/path/to/task.json", "task"},
+		{"task.yaml", "task"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := extractJUnitClassname(tt.input)
+			if got != tt.want {
+				t.Errorf("extractJUnitClassname(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cli/result.go
+++ b/pkg/cli/result.go
@@ -18,6 +18,7 @@ These commands operate on the JSON result files produced by 'mcpchecker check'.`
 	resultCmd.AddCommand(NewVerifyCmd())
 	resultCmd.AddCommand(NewSummaryCmd())
 	resultCmd.AddCommand(NewDiffCmd())
+	resultCmd.AddCommand(NewJUnitCmd())
 
 	return resultCmd
 }

--- a/pkg/cli/result.go
+++ b/pkg/cli/result.go
@@ -18,7 +18,7 @@ These commands operate on the JSON result files produced by 'mcpchecker check'.`
 	resultCmd.AddCommand(NewVerifyCmd())
 	resultCmd.AddCommand(NewSummaryCmd())
 	resultCmd.AddCommand(NewDiffCmd())
-	resultCmd.AddCommand(NewJUnitCmd())
+	resultCmd.AddCommand(NewConvertCmd())
 
 	return resultCmd
 }


### PR DESCRIPTION
Fixes #216 

Added `junit` subcommand command nested to `result` command to convert of test result produced by check to JUnit XML format.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `convert` command with JUnit XML export capability for test results
  * Supports optional task filtering and custom output file specification

* **Tests**
  * Comprehensive test suite for JUnit XML conversion functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->