### PR TITLE
refactor(eval): use context.WithoutCancel for cleanup context

### DIFF
--- a/pkg/eval/runner.go
+++ b/pkg/eval/runner.go
@@ -774,16 +774,10 @@ func (r *evalRunner) runTask(
 	}
 
 	// Defer cleanup with its own timeout context, independent of task timeout.
-	// Build on a fresh background context so the task deadline doesn't propagate,
-	// but re-attach managers so cleanup steps can use extensions and MCP servers.
+	// WithoutCancel preserves all context values (managers, judges, etc.)
+	// while detaching from the parent's deadline/cancellation.
 	defer func() {
-		cleanupBase := context.Background()
-		if mgr, ok := client.ManagerFromContext(ctx); ok {
-			cleanupBase = client.ManagerToContext(cleanupBase, mgr)
-		}
-		if mgr, ok := mcpclient.ManagerFromContext(ctx); ok {
-			cleanupBase = mcpclient.ManagerToContext(cleanupBase, mgr)
-		}
+		cleanupBase := context.WithoutCancel(ctx)
 
 		var cleanupCtx context.Context
 		var cleanupCancel context.CancelFunc


### PR DESCRIPTION
followup to pr #296 

Replace manual manager forwarding with context.WithoutCancel so new context values are automatically available in cleanup without updating the forwarding logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal cleanup context handling during task execution for better resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->