### PR TITLE
feat: add lockfile and source types

### DIFF
--- a/pkg/eval/config.go
+++ b/pkg/eval/config.go
@@ -3,7 +3,9 @@ package eval
 import (
 	"fmt"
 	"os"
+	gopath "path"
 	"path/filepath"
+	"strings"
 
 	"sigs.k8s.io/yaml"
 
@@ -42,6 +44,9 @@ type EvalConfig struct {
 	// Extensions configuration
 	Extensions map[string]*extension.ExtensionSpec `json:"extensions"`
 
+	// Sources defines cross-repo eval sources keyed by name
+	Sources map[string]*SourceSpec `json:"sources,omitempty"`
+
 	// MCP configuration
 	McpConfigFile string                       `json:"mcpConfigFile"`
 	LLMJudge      *llmjudge.LLMJudgeEvalConfig `json:"llmJudge"`
@@ -54,10 +59,21 @@ type EvalConfig struct {
 	TaskSets []TaskSet `json:"taskSets,omitempty"`
 }
 
+// SourceSpec defines a cross-repo eval source
+type SourceSpec struct {
+	Repo          string            `json:"repo"`
+	Ref           string            `json:"ref"`
+	ServerMapping map[string]string `json:"serverMapping,omitempty"`
+}
+
 type TaskSet struct {
 	// Exactly one of Glob or Path must be set
 	Glob string `json:"glob,omitempty"`
 	Path string `json:"path,omitempty"`
+
+	// Source references a key in EvalConfig.Sources.
+	// Mutually exclusive with absolute local paths.
+	Source string `json:"source,omitempty"`
 
 	// Optional label selector - filters tasks by labels
 	// All specified labels must match (AND logic)
@@ -148,20 +164,95 @@ func Read(data []byte, basePath string) (*EvalSpec, error) {
 		return nil, fmt.Errorf("failed to resolve mcp config file path: %w", err)
 	}
 
-	// Resolve task set paths and globs
+	// Validate source specs
+	for name, src := range spec.Config.Sources {
+		if err := validateSourceSpec(name, src); err != nil {
+			return nil, err
+		}
+	}
+
+	// Resolve task set paths/globs and validate source references
 	for i := range spec.Config.TaskSets {
-		if spec.Config.TaskSets[i].Path != "" {
-			if err := resolveFilePath(&spec.Config.TaskSets[i].Path, basePath); err != nil {
+		ts := &spec.Config.TaskSets[i]
+		if ts.Source != "" {
+			if err := ts.validateSource(spec.Config.Sources); err != nil {
+				return nil, fmt.Errorf("taskSet[%d]: %w", i, err)
+			}
+		} else if ts.Path != "" {
+			if err := resolveFilePath(&ts.Path, basePath); err != nil {
 				return nil, fmt.Errorf("failed to resolve task set path at index %d: %w", i, err)
 			}
-		} else if spec.Config.TaskSets[i].Glob != "" {
-			if err := resolveFilePath(&spec.Config.TaskSets[i].Glob, basePath); err != nil {
+		} else if ts.Glob != "" {
+			if err := resolveFilePath(&ts.Glob, basePath); err != nil {
 				return nil, fmt.Errorf("failed to resolve task set glob at index %d: %w", i, err)
 			}
 		}
 	}
 
 	return spec, nil
+}
+
+// taskPath returns the set path value and its kind ("path" or "glob").
+func (ts *TaskSet) taskPath() (string, string) {
+	if ts.Path != "" {
+		return ts.Path, "path"
+	}
+
+	return ts.Glob, "glob"
+}
+
+func (ts *TaskSet) validateSource(sources map[string]*SourceSpec) error {
+	if sources == nil {
+		return fmt.Errorf("references source %q but no sources are defined", ts.Source)
+	}
+
+	if _, ok := sources[ts.Source]; !ok {
+		return fmt.Errorf("references undefined source %q", ts.Source)
+	}
+
+	taskPath, pathKind := ts.taskPath()
+	if taskPath != "" {
+		if gopath.IsAbs(taskPath) || filepath.IsAbs(taskPath) {
+			return fmt.Errorf(
+				"has source %q but %s %q is absolute; sourced task sets must use relative paths",
+				ts.Source,
+				pathKind,
+				taskPath,
+			)
+		}
+
+		if err := validateNoPathEscape(taskPath); err != nil {
+			return fmt.Errorf("%s escapes source repo root: %w", pathKind, err)
+		}
+	}
+
+	return nil
+}
+
+func validateSourceSpec(name string, src *SourceSpec) error {
+	if src == nil {
+		return fmt.Errorf("source %q is nil", name)
+	}
+
+	if src.Repo == "" {
+		return fmt.Errorf("source %q requires a repo field", name)
+	}
+
+	if src.Ref == "" {
+		return fmt.Errorf("source %q requires a ref field", name)
+	}
+
+	return nil
+}
+
+// validateNoPathEscape checks that a relative path does not escape above the root via "../"
+func validateNoPathEscape(p string) error {
+	cleaned := gopath.Clean(p)
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return fmt.Errorf("path %q escapes the repo root", p)
+	}
+
+	return nil
 }
 
 func resolveFilePath(filePath *string, basePath string) error {

--- a/pkg/eval/config_test.go
+++ b/pkg/eval/config_test.go
@@ -1,0 +1,138 @@
+package eval
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testDataPath = "testdata"
+)
+
+func TestReadSourceSpec(t *testing.T) {
+	basePath, err := os.Getwd()
+	require.NoError(t, err)
+	basePath = filepath.Join(basePath, testDataPath)
+
+	tests := map[string]struct {
+		file        string
+		expectErr   bool
+		errContains string
+		validate    func(t *testing.T, spec *EvalSpec)
+	}{
+		"valid config with sources": {
+			file: "source-valid.yaml",
+			validate: func(t *testing.T, spec *EvalSpec) {
+				require.Len(t, spec.Config.Sources, 1)
+				src := spec.Config.Sources["upstream"]
+				assert.Equal(t, "github.com/org/repo", src.Repo)
+				assert.Equal(t, "main", src.Ref)
+				require.Len(t, spec.Config.TaskSets, 1)
+				assert.Equal(t, "upstream", spec.Config.TaskSets[0].Source)
+				assert.Equal(t, "tasks/*.yaml", spec.Config.TaskSets[0].Glob)
+			},
+		},
+		"valid config with source and serverMapping": {
+			file: "source-with-server-mapping.yaml",
+			validate: func(t *testing.T, spec *EvalSpec) {
+				src := spec.Config.Sources["upstream"]
+				assert.Equal(t, map[string]string{"their-server": "my-server"}, src.ServerMapping)
+				assert.Equal(t, "upstream", spec.Config.TaskSets[0].Source)
+			},
+		},
+		"valid config without sources": {
+			file: "source-no-sources.yaml",
+			validate: func(t *testing.T, spec *EvalSpec) {
+				assert.Nil(t, spec.Config.Sources)
+				assert.Empty(t, spec.Config.TaskSets[0].Source)
+			},
+		},
+		"multiple sources": {
+			file: "source-multiple.yaml",
+			validate: func(t *testing.T, spec *EvalSpec) {
+				require.Len(t, spec.Config.Sources, 2)
+				assert.Equal(t, "github.com/org/repo-a", spec.Config.Sources["upstream"].Repo)
+				assert.Equal(t, "github.com/org/repo-b", spec.Config.Sources["other"].Repo)
+				assert.Equal(t, "upstream", spec.Config.TaskSets[0].Source)
+				assert.Equal(t, "other", spec.Config.TaskSets[1].Source)
+			},
+		},
+		"sourced taskSet with relative path within repo": {
+			file: "source-relative-path-within-repo.yaml",
+			validate: func(t *testing.T, spec *EvalSpec) {
+				assert.Equal(t, "upstream", spec.Config.TaskSets[0].Source)
+				assert.Equal(t, "subdir/../tasks/test.yaml", spec.Config.TaskSets[0].Path)
+			},
+		},
+		"source missing repo": {
+			file:        "source-missing-repo.yaml",
+			expectErr:   true,
+			errContains: `source "upstream" requires a repo field`,
+		},
+		"source missing ref": {
+			file:        "source-missing-ref.yaml",
+			expectErr:   true,
+			errContains: `source "upstream" requires a ref field`,
+		},
+		"taskSet references undefined source": {
+			file:        "source-undefined-ref.yaml",
+			expectErr:   true,
+			errContains: `references undefined source "nonexistent"`,
+		},
+		"taskSet references source but no sources defined": {
+			file:        "source-no-sources-defined.yaml",
+			expectErr:   true,
+			errContains: "no sources are defined",
+		},
+		"sourced taskSet with absolute path": {
+			file:        "source-absolute-path.yaml",
+			expectErr:   true,
+			errContains: "is absolute; sourced task sets must use relative paths",
+		},
+		"sourced taskSet with absolute glob": {
+			file:        "source-absolute-glob.yaml",
+			expectErr:   true,
+			errContains: "is absolute; sourced task sets must use relative paths",
+		},
+		"sourced taskSet with path escaping repo root": {
+			file:        "source-path-escape.yaml",
+			expectErr:   true,
+			errContains: "escapes source repo root",
+		},
+		"sourced taskSet with glob escaping repo root": {
+			file:        "source-glob-escape.yaml",
+			expectErr:   true,
+			errContains: "escapes source repo root",
+		},
+		"sourced taskSet with disguised path escape": {
+			file:        "source-disguised-path-escape.yaml",
+			expectErr:   true,
+			errContains: "escapes source repo root",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(fmt.Sprintf("%s/%s", basePath, tc.file))
+			require.NoError(t, err)
+
+			spec, err := Read(data, basePath)
+			if tc.expectErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tc.validate != nil {
+				tc.validate(t, spec)
+			}
+		})
+	}
+}

--- a/pkg/eval/testdata/source-absolute-glob.yaml
+++ b/pkg/eval/testdata/source-absolute-glob.yaml
@@ -1,0 +1,9 @@
+kind: Eval
+config:
+  sources:
+    upstream:
+      repo: github.com/org/repo
+      ref: main
+  taskSets:
+    - source: upstream
+      glob: /absolute/glob/*.yaml

--- a/pkg/eval/testdata/source-absolute-path.yaml
+++ b/pkg/eval/testdata/source-absolute-path.yaml
@@ -1,0 +1,9 @@
+kind: Eval
+config:
+  sources:
+    upstream:
+      repo: github.com/org/repo
+      ref: main
+  taskSets:
+    - source: upstream
+      path: /absolute/path/test.yaml

--- a/pkg/eval/testdata/source-disguised-path-escape.yaml
+++ b/pkg/eval/testdata/source-disguised-path-escape.yaml
@@ -1,0 +1,9 @@
+kind: Eval
+config:
+  sources:
+    upstream:
+      repo: github.com/org/repo
+      ref: main
+  taskSets:
+    - source: upstream
+      path: subdir/../../../etc/passwd

--- a/pkg/eval/testdata/source-glob-escape.yaml
+++ b/pkg/eval/testdata/source-glob-escape.yaml
@@ -1,0 +1,9 @@
+kind: Eval
+config:
+  sources:
+    upstream:
+      repo: github.com/org/repo
+      ref: main
+  taskSets:
+    - source: upstream
+      glob: ../../../*.yaml

--- a/pkg/eval/testdata/source-missing-ref.yaml
+++ b/pkg/eval/testdata/source-missing-ref.yaml
@@ -1,0 +1,5 @@
+kind: Eval
+config:
+  sources:
+    upstream:
+      repo: github.com/org/repo

--- a/pkg/eval/testdata/source-missing-repo.yaml
+++ b/pkg/eval/testdata/source-missing-repo.yaml
@@ -1,0 +1,5 @@
+kind: Eval
+config:
+  sources:
+    upstream:
+      ref: main

--- a/pkg/eval/testdata/source-multiple.yaml
+++ b/pkg/eval/testdata/source-multiple.yaml
@@ -1,0 +1,14 @@
+kind: Eval
+config:
+  sources:
+    upstream:
+      repo: github.com/org/repo-a
+      ref: main
+    other:
+      repo: github.com/org/repo-b
+      ref: v2.0.0
+  taskSets:
+    - source: upstream
+      glob: "tasks/*.yaml"
+    - source: other
+      path: tests/basic.yaml

--- a/pkg/eval/testdata/source-no-sources-defined.yaml
+++ b/pkg/eval/testdata/source-no-sources-defined.yaml
@@ -1,0 +1,5 @@
+kind: Eval
+config:
+  taskSets:
+    - source: upstream
+      glob: "tasks/*.yaml"

--- a/pkg/eval/testdata/source-no-sources.yaml
+++ b/pkg/eval/testdata/source-no-sources.yaml
@@ -1,0 +1,4 @@
+kind: Eval
+config:
+  taskSets:
+    - path: tasks/test.yaml

--- a/pkg/eval/testdata/source-path-escape.yaml
+++ b/pkg/eval/testdata/source-path-escape.yaml
@@ -1,0 +1,9 @@
+kind: Eval
+config:
+  sources:
+    upstream:
+      repo: github.com/org/repo
+      ref: main
+  taskSets:
+    - source: upstream
+      path: ../../etc/passwd

--- a/pkg/eval/testdata/source-relative-path-within-repo.yaml
+++ b/pkg/eval/testdata/source-relative-path-within-repo.yaml
@@ -1,0 +1,9 @@
+kind: Eval
+config:
+  sources:
+    upstream:
+      repo: github.com/org/repo
+      ref: main
+  taskSets:
+    - source: upstream
+      path: subdir/../tasks/test.yaml

--- a/pkg/eval/testdata/source-undefined-ref.yaml
+++ b/pkg/eval/testdata/source-undefined-ref.yaml
@@ -1,0 +1,9 @@
+kind: Eval
+config:
+  sources:
+    upstream:
+      repo: github.com/org/repo
+      ref: main
+  taskSets:
+    - source: nonexistent
+      glob: "tasks/*.yaml"

--- a/pkg/eval/testdata/source-valid.yaml
+++ b/pkg/eval/testdata/source-valid.yaml
@@ -1,0 +1,9 @@
+kind: Eval
+config:
+  sources:
+    upstream:
+      repo: github.com/org/repo
+      ref: main
+  taskSets:
+    - source: upstream
+      glob: "tasks/*.yaml"

--- a/pkg/eval/testdata/source-with-server-mapping.yaml
+++ b/pkg/eval/testdata/source-with-server-mapping.yaml
@@ -1,0 +1,11 @@
+kind: Eval
+config:
+  sources:
+    upstream:
+      repo: github.com/org/repo
+      ref: v1.0.0
+      serverMapping:
+        their-server: my-server
+  taskSets:
+    - source: upstream
+      path: tasks/test.yaml

--- a/pkg/lockfile/lockfile.go
+++ b/pkg/lockfile/lockfile.go
@@ -1,0 +1,126 @@
+package lockfile
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"time"
+
+	"sigs.k8s.io/yaml"
+)
+
+const CurrentVersion = 1
+
+var (
+	commitSHARegex = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	hashRegex      = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+)
+
+type Lockfile struct {
+	Version    int                      `json:"version"`              // version of lockfile, in case we make breaking changes in the future
+	Sources    map[string]SourceLock    `json:"sources,omitempty"`    // which sources are installed
+	Extensions map[string]ExtensionLock `json:"extensions,omitempty"` // which extensions are installed
+}
+
+type SourceLock struct {
+	Repo      string `json:"repo"`      // repo of the source
+	Ref       string `json:"ref"`       // ref in the git repo of the source
+	Commit    string `json:"commit"`    // specific resolved commit of the source
+	Hash      string `json:"hash"`      // hashed contents of the source, for verification of contents
+	FetchedAt time.Time `json:"fetchedAt"` // time the contents were fetched
+}
+
+type ExtensionLock struct {
+	Package   string    `json:"package"`   // package installed (since extensions go through package, not full repo download)
+	Version   string    `json:"version"`   // version of the package
+	Hash      string    `json:"hash"`      // hashed contents of the package, for verification of contents
+	FetchedAt time.Time `json:"fetchedAt"` // time the contents were fetched
+}
+
+func Read(data []byte) (*Lockfile, error) {
+	lf := &Lockfile{}
+	if err := yaml.Unmarshal(data, lf); err != nil {
+		return nil, fmt.Errorf("failed to parse lockfile: %w", err)
+	}
+
+	if err := lf.Validate(); err != nil {
+		return nil, err
+	}
+
+	return lf, nil
+}
+
+func FromFile(path string) (*Lockfile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read lockfile %q: %w", path, err)
+	}
+
+	return Read(data)
+}
+
+func (lf *Lockfile) Write() ([]byte, error) {
+	data, err := yaml.Marshal(lf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal lockfile: %w", err)
+	}
+
+	return data, nil
+}
+
+func (lf *Lockfile) WriteToFile(path string) error {
+	data, err := lf.Write()
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0644)
+}
+
+func (lf *Lockfile) Validate() error {
+	if lf.Version != CurrentVersion {
+		return fmt.Errorf("unsupported lockfile version: %d", lf.Version)
+	}
+
+	for name, src := range lf.Sources {
+		if src.Repo == "" {
+			return fmt.Errorf("source %q has empty repo", name)
+		}
+
+		if src.Ref == "" {
+			return fmt.Errorf("source %q has empty ref", name)
+		}
+
+		if !commitSHARegex.MatchString(src.Commit) {
+			return fmt.Errorf("source %q has invalid commit SHA %q: must be a 40-character hex string", name, src.Commit)
+		}
+
+		if !hashRegex.MatchString(src.Hash) {
+			return fmt.Errorf("source %q has invalid hash %q: must be sha256:<64 hex chars>", name, src.Hash)
+		}
+
+		if src.FetchedAt.IsZero() {
+			return fmt.Errorf("source %q has empty fetchedAt", name)
+		}
+	}
+
+	for name, ext := range lf.Extensions {
+		if ext.Package == "" {
+			return fmt.Errorf("extension %q has empty package", name)
+		}
+
+		if ext.Version == "" {
+			return fmt.Errorf("extension %q has empty version", name)
+		}
+
+		if !hashRegex.MatchString(ext.Hash) {
+			return fmt.Errorf("extension %q has invalid hash %q: must be sha256:<64 hex chars>", name, ext.Hash)
+		}
+
+		if ext.FetchedAt.IsZero() {
+			return fmt.Errorf("extension %q has empty fetchedAt", name)
+		}
+	}
+
+	return nil
+}

--- a/pkg/lockfile/lockfile_test.go
+++ b/pkg/lockfile/lockfile_test.go
@@ -1,0 +1,199 @@
+package lockfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testDataPath = "testdata"
+
+func TestReadLockfile(t *testing.T) {
+	basePath, err := os.Getwd()
+	require.NoError(t, err)
+	basePath = filepath.Join(basePath, testDataPath)
+
+	tests := map[string]struct {
+		file        string
+		expectErr   bool
+		errContains string
+		validate    func(t *testing.T, lf *Lockfile)
+	}{
+		"valid lockfile with sources and extensions": {
+			file: "valid.yaml",
+			validate: func(t *testing.T, lf *Lockfile) {
+				assert.Equal(t, 1, lf.Version)
+				require.Len(t, lf.Sources, 1)
+				src := lf.Sources["upstream"]
+				assert.Equal(t, "github.com/org/repo", src.Repo)
+				assert.Equal(t, "main", src.Ref)
+				assert.Equal(t, "abc123def456789012345678901234567890abcd", src.Commit)
+				assert.Equal(t, "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", src.Hash)
+				assert.Equal(t, time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC), src.FetchedAt)
+				require.Len(t, lf.Extensions, 1)
+				ext := lf.Extensions["my-ext"]
+				assert.Equal(t, "github.com/org/ext", ext.Package)
+				assert.Equal(t, "v1.2.3", ext.Version)
+				assert.Equal(t, "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", ext.Hash)
+			},
+		},
+		"valid lockfile with sources only": {
+			file: "valid-sources-only.yaml",
+			validate: func(t *testing.T, lf *Lockfile) {
+				require.Len(t, lf.Sources, 1)
+				assert.Equal(t, "v1.0.0", lf.Sources["upstream"].Ref)
+				assert.Empty(t, lf.Extensions)
+			},
+		},
+		"valid lockfile with extensions only": {
+			file: "valid-extensions-only.yaml",
+			validate: func(t *testing.T, lf *Lockfile) {
+				assert.Empty(t, lf.Sources)
+				require.Len(t, lf.Extensions, 1)
+				assert.Equal(t, "v2.0.0", lf.Extensions["my-ext"].Version)
+			},
+		},
+		"invalid commit - too short": {
+			file:        "invalid-commit-short.yaml",
+			expectErr:   true,
+			errContains: "invalid commit SHA",
+		},
+		"invalid commit - uppercase": {
+			file:        "invalid-commit-uppercase.yaml",
+			expectErr:   true,
+			errContains: "invalid commit SHA",
+		},
+		"invalid commit - non-hex characters": {
+			file:        "invalid-commit-non-hex.yaml",
+			expectErr:   true,
+			errContains: "invalid commit SHA",
+		},
+		"invalid commit - empty": {
+			file:        "invalid-commit-empty.yaml",
+			expectErr:   true,
+			errContains: "invalid commit SHA",
+		},
+		"invalid source hash - too short": {
+			file:        "invalid-hash-short.yaml",
+			expectErr:   true,
+			errContains: "invalid hash",
+		},
+		"invalid source hash - missing sha256 prefix": {
+			file:        "invalid-hash-no-prefix.yaml",
+			expectErr:   true,
+			errContains: "invalid hash",
+		},
+		"invalid extension hash": {
+			file:        "invalid-extension-hash.yaml",
+			expectErr:   true,
+			errContains: "invalid hash",
+		},
+		"invalid source - empty repo": {
+			file:        "invalid-source-empty-repo.yaml",
+			expectErr:   true,
+			errContains: `source "upstream" has empty repo`,
+		},
+		"invalid source - empty ref": {
+			file:        "invalid-source-empty-ref.yaml",
+			expectErr:   true,
+			errContains: `source "upstream" has empty ref`,
+		},
+		"invalid source - empty fetchedAt": {
+			file:        "invalid-source-empty-fetchedat.yaml",
+			expectErr:   true,
+			errContains: "failed to parse lockfile",
+		},
+		"invalid source - bad fetchedAt format": {
+			file:        "invalid-source-bad-fetchedat.yaml",
+			expectErr:   true,
+			errContains: "failed to parse lockfile",
+		},
+		"invalid extension - empty package": {
+			file:        "invalid-extension-empty-package.yaml",
+			expectErr:   true,
+			errContains: `extension "my-ext" has empty package`,
+		},
+		"invalid extension - empty version": {
+			file:        "invalid-extension-empty-version.yaml",
+			expectErr:   true,
+			errContains: `extension "my-ext" has empty version`,
+		},
+		"invalid extension - empty fetchedAt": {
+			file:        "invalid-extension-empty-fetchedat.yaml",
+			expectErr:   true,
+			errContains: "failed to parse lockfile",
+		},
+		"invalid extension - bad fetchedAt format": {
+			file:        "invalid-extension-bad-fetchedat.yaml",
+			expectErr:   true,
+			errContains: "failed to parse lockfile",
+		},
+		"invalid version - zero (missing)": {
+			file:        "invalid-version-zero.yaml",
+			expectErr:   true,
+			errContains: "unsupported lockfile version: 0",
+		},
+		"invalid version - future": {
+			file:        "invalid-version-future.yaml",
+			expectErr:   true,
+			errContains: "unsupported lockfile version: 2",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(fmt.Sprintf("%s/%s", basePath, tc.file))
+			require.NoError(t, err)
+
+			lf, err := Read(data)
+			if tc.expectErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tc.validate != nil {
+				tc.validate(t, lf)
+			}
+		})
+	}
+}
+
+func TestLockfileRoundTrip(t *testing.T) {
+	basePath, err := os.Getwd()
+	require.NoError(t, err)
+	basePath = filepath.Join(basePath, testDataPath)
+
+	tests := map[string]struct {
+		file string
+	}{
+		"sources and extensions": {file: "valid.yaml"},
+		"sources only":          {file: "valid-sources-only.yaml"},
+		"extensions only":       {file: "valid-extensions-only.yaml"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(fmt.Sprintf("%s/%s", basePath, tc.file))
+			require.NoError(t, err)
+
+			original, err := Read(data)
+			require.NoError(t, err)
+
+			written, err := original.Write()
+			require.NoError(t, err)
+
+			roundTripped, err := Read(written)
+			require.NoError(t, err)
+
+			assert.Equal(t, original, roundTripped)
+		})
+	}
+}

--- a/pkg/lockfile/testdata/invalid-commit-empty.yaml
+++ b/pkg/lockfile/testdata/invalid-commit-empty.yaml
@@ -1,0 +1,8 @@
+version: 1
+sources:
+  upstream:
+    repo: github.com/org/repo
+    ref: main
+    commit: ""
+    hash: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    fetchedAt: "2025-01-15T10:30:00Z"

--- a/pkg/lockfile/testdata/invalid-commit-non-hex.yaml
+++ b/pkg/lockfile/testdata/invalid-commit-non-hex.yaml
@@ -1,0 +1,8 @@
+version: 1
+sources:
+  upstream:
+    repo: github.com/org/repo
+    ref: main
+    commit: xyz123def456789012345678901234567890abcd
+    hash: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    fetchedAt: "2025-01-15T10:30:00Z"

--- a/pkg/lockfile/testdata/invalid-commit-short.yaml
+++ b/pkg/lockfile/testdata/invalid-commit-short.yaml
@@ -1,0 +1,8 @@
+version: 1
+sources:
+  upstream:
+    repo: github.com/org/repo
+    ref: main
+    commit: abc123
+    hash: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    fetchedAt: "2025-01-15T10:30:00Z"

--- a/pkg/lockfile/testdata/invalid-commit-uppercase.yaml
+++ b/pkg/lockfile/testdata/invalid-commit-uppercase.yaml
@@ -1,0 +1,8 @@
+version: 1
+sources:
+  upstream:
+    repo: github.com/org/repo
+    ref: main
+    commit: ABC123DEF456789012345678901234567890ABCD
+    hash: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    fetchedAt: "2025-01-15T10:30:00Z"

--- a/pkg/lockfile/testdata/invalid-extension-bad-fetchedat.yaml
+++ b/pkg/lockfile/testdata/invalid-extension-bad-fetchedat.yaml
@@ -1,0 +1,7 @@
+version: 1
+extensions:
+  my-ext:
+    package: github.com/org/ext
+    version: v1.2.3
+    hash: sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+    fetchedAt: "Jan 15, 2025"

--- a/pkg/lockfile/testdata/invalid-extension-empty-fetchedat.yaml
+++ b/pkg/lockfile/testdata/invalid-extension-empty-fetchedat.yaml
@@ -1,0 +1,7 @@
+version: 1
+extensions:
+  my-ext:
+    package: github.com/org/ext
+    version: v1.2.3
+    hash: sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+    fetchedAt: ""

--- a/pkg/lockfile/testdata/invalid-extension-empty-package.yaml
+++ b/pkg/lockfile/testdata/invalid-extension-empty-package.yaml
@@ -1,0 +1,7 @@
+version: 1
+extensions:
+  my-ext:
+    package: ""
+    version: v1.2.3
+    hash: sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+    fetchedAt: "2025-01-15T10:30:00Z"

--- a/pkg/lockfile/testdata/invalid-extension-empty-version.yaml
+++ b/pkg/lockfile/testdata/invalid-extension-empty-version.yaml
@@ -1,0 +1,7 @@
+version: 1
+extensions:
+  my-ext:
+    package: github.com/org/ext
+    version: ""
+    hash: sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+    fetchedAt: "2025-01-15T10:30:00Z"

--- a/pkg/lockfile/testdata/invalid-extension-hash.yaml
+++ b/pkg/lockfile/testdata/invalid-extension-hash.yaml
@@ -1,0 +1,7 @@
+version: 1
+extensions:
+  my-ext:
+    package: github.com/org/ext
+    version: v1.0.0
+    hash: sha256:tooshort
+    fetchedAt: "2025-01-15T10:30:00Z"

--- a/pkg/lockfile/testdata/invalid-hash-no-prefix.yaml
+++ b/pkg/lockfile/testdata/invalid-hash-no-prefix.yaml
@@ -1,0 +1,8 @@
+version: 1
+sources:
+  upstream:
+    repo: github.com/org/repo
+    ref: main
+    commit: abc123def456789012345678901234567890abcd
+    hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    fetchedAt: "2025-01-15T10:30:00Z"

--- a/pkg/lockfile/testdata/invalid-hash-short.yaml
+++ b/pkg/lockfile/testdata/invalid-hash-short.yaml
@@ -1,0 +1,8 @@
+version: 1
+sources:
+  upstream:
+    repo: github.com/org/repo
+    ref: main
+    commit: abc123def456789012345678901234567890abcd
+    hash: sha256:deadbeef
+    fetchedAt: "2025-01-15T10:30:00Z"

--- a/pkg/lockfile/testdata/invalid-source-bad-fetchedat.yaml
+++ b/pkg/lockfile/testdata/invalid-source-bad-fetchedat.yaml
@@ -1,0 +1,8 @@
+version: 1
+sources:
+  upstream:
+    repo: github.com/org/repo
+    ref: main
+    commit: 0123456789abcdef0123456789abcdef01234567
+    hash: sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+    fetchedAt: "2025-01-15 10:30:00"

--- a/pkg/lockfile/testdata/invalid-source-empty-fetchedat.yaml
+++ b/pkg/lockfile/testdata/invalid-source-empty-fetchedat.yaml
@@ -1,0 +1,8 @@
+version: 1
+sources:
+  upstream:
+    repo: github.com/org/repo
+    ref: main
+    commit: 0123456789abcdef0123456789abcdef01234567
+    hash: sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+    fetchedAt: ""

--- a/pkg/lockfile/testdata/invalid-source-empty-ref.yaml
+++ b/pkg/lockfile/testdata/invalid-source-empty-ref.yaml
@@ -1,0 +1,8 @@
+version: 1
+sources:
+  upstream:
+    repo: github.com/org/repo
+    ref: ""
+    commit: 0123456789abcdef0123456789abcdef01234567
+    hash: sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+    fetchedAt: "2025-01-15T10:30:00Z"

--- a/pkg/lockfile/testdata/invalid-source-empty-repo.yaml
+++ b/pkg/lockfile/testdata/invalid-source-empty-repo.yaml
@@ -1,0 +1,8 @@
+version: 1
+sources:
+  upstream:
+    repo: ""
+    ref: main
+    commit: 0123456789abcdef0123456789abcdef01234567
+    hash: sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+    fetchedAt: "2025-01-15T10:30:00Z"

--- a/pkg/lockfile/testdata/invalid-version-future.yaml
+++ b/pkg/lockfile/testdata/invalid-version-future.yaml
@@ -1,0 +1,8 @@
+version: 2
+sources:
+  upstream:
+    repo: github.com/org/repo
+    ref: v1.0.0
+    commit: 0123456789abcdef0123456789abcdef01234567
+    hash: sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+    fetchedAt: "2025-02-01T00:00:00Z"

--- a/pkg/lockfile/testdata/invalid-version-zero.yaml
+++ b/pkg/lockfile/testdata/invalid-version-zero.yaml
@@ -1,0 +1,7 @@
+sources:
+  upstream:
+    repo: github.com/org/repo
+    ref: v1.0.0
+    commit: 0123456789abcdef0123456789abcdef01234567
+    hash: sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+    fetchedAt: "2025-02-01T00:00:00Z"

--- a/pkg/lockfile/testdata/valid-extensions-only.yaml
+++ b/pkg/lockfile/testdata/valid-extensions-only.yaml
@@ -1,0 +1,7 @@
+version: 1
+extensions:
+  my-ext:
+    package: github.com/org/ext
+    version: v2.0.0
+    hash: sha256:d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592
+    fetchedAt: "2025-03-01T12:00:00Z"

--- a/pkg/lockfile/testdata/valid-sources-only.yaml
+++ b/pkg/lockfile/testdata/valid-sources-only.yaml
@@ -1,0 +1,8 @@
+version: 1
+sources:
+  upstream:
+    repo: github.com/org/repo
+    ref: v1.0.0
+    commit: 0123456789abcdef0123456789abcdef01234567
+    hash: sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+    fetchedAt: "2025-02-01T00:00:00Z"

--- a/pkg/lockfile/testdata/valid.yaml
+++ b/pkg/lockfile/testdata/valid.yaml
@@ -1,0 +1,14 @@
+version: 1
+sources:
+  upstream:
+    repo: github.com/org/repo
+    ref: main
+    commit: abc123def456789012345678901234567890abcd
+    hash: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    fetchedAt: "2025-01-15T10:30:00Z"
+extensions:
+  my-ext:
+    package: github.com/org/ext
+    version: v1.2.3
+    hash: sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+    fetchedAt: "2025-01-15T10:30:00Z"


### PR DESCRIPTION
Fixes #280 

This adds types for the lockfile and the sources, as well as validation for both and extensive unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for sourcing/evaluating tasks from named external repositories with path/glob validation to prevent absolute paths and escapes.
  * New lockfile format to record sources and extensions with integrity and timestamp checks.
* **Tests**
  * Added comprehensive tests and fixtures covering source resolution/validation and lockfile parsing/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->