### PR TITLE
feat(eval): add git tasksource resolver

### DIFF
--- a/pkg/eval/tasksource/git.go
+++ b/pkg/eval/tasksource/git.go
@@ -1,0 +1,260 @@
+package tasksource
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// GitResolverOption configures a gitResolver.
+type GitResolverOption func(*gitResolver)
+
+// WithCacheDir sets the local directory used to cache fetched sources.
+// Defaults to ~/.mcpchecker/sources.
+func WithCacheDir(dir string) GitResolverOption {
+	return func(r *gitResolver) {
+		r.cacheDir = dir
+	}
+}
+
+type gitResolver struct {
+	cacheDir string
+	gitBin   string
+}
+
+var fullSHAPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+// NewGitResolver creates a Resolver that fetches task sources from git
+// repositories and caches them locally. It shells out to the git binary,
+// inheriting the user's existing credentials and configuration.
+func NewGitResolver(opts ...GitResolverOption) (Resolver, error) {
+	gitBin, err := exec.LookPath("git")
+	if err != nil {
+		return nil, fmt.Errorf("git not found in PATH: %w", err)
+	}
+
+	r := &gitResolver{
+		gitBin: gitBin,
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	if r.cacheDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine home directory: %w", err)
+		}
+		r.cacheDir = filepath.Join(home, ".mcpchecker", "sources")
+	}
+
+	if err := os.MkdirAll(r.cacheDir, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	return r, nil
+}
+
+func (r *gitResolver) Resolve(ctx context.Context, repo, ref string) (string, string, error) {
+	repoURL := toRepoURL(repo)
+
+	sha, err := r.resolveRef(ctx, repoURL, ref)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to resolve ref %q: %w", ref, err)
+	}
+
+	cacheKey := repoCacheKey(repo)
+	dir := filepath.Join(r.cacheDir, cacheKey, sha)
+
+	// Cache hit — directory already exists.
+	if info, err := os.Stat(dir); err == nil && info.IsDir() {
+		return dir, sha, nil
+	}
+
+	if err := r.cloneAt(ctx, repoURL, sha, dir); err != nil {
+		return "", "", fmt.Errorf("failed to fetch source: %w", err)
+	}
+
+	return dir, sha, nil
+}
+
+// resolveRef resolves a git ref (branch, tag, or SHA) to a full commit SHA.
+// If ref is already a 40-character hex string it is returned directly.
+// Otherwise git ls-remote is used, preferring peeled refs so annotated tags
+// resolve to the underlying commit.
+func (r *gitResolver) resolveRef(ctx context.Context, repoURL, ref string) (string, error) {
+	if fullSHAPattern.MatchString(ref) {
+		return ref, nil
+	}
+
+	out, err := r.git(ctx, "ls-remote", repoURL, ref)
+	if err != nil {
+		return "", err
+	}
+
+	if out == "" {
+		return "", fmt.Errorf("ref %q not found in %s", ref, repoURL)
+	}
+
+	// Parse output — prefer peeled refs (^{}) for annotated tags.
+	var sha, peeledSHA string
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		if strings.HasSuffix(fields[1], "^{}") {
+			peeledSHA = fields[0]
+		} else if sha == "" {
+			sha = fields[0]
+		}
+	}
+
+	if peeledSHA != "" {
+		return peeledSHA, nil
+	}
+
+	if sha != "" {
+		return sha, nil
+	}
+
+	return "", fmt.Errorf("could not parse SHA from ls-remote output for ref %q", ref)
+}
+
+// cloneAt fetches the tree at the given SHA into destDir. Extraction is atomic:
+// content is written to a temp directory first, then renamed into place so a
+// partial fetch never leaves a broken cache entry.
+func (r *gitResolver) cloneAt(ctx context.Context, repoURL, sha, destDir string) error {
+	parentDir := filepath.Dir(destDir)
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create parent directory: %w", err)
+	}
+
+	tmpDir, err := os.MkdirTemp(parentDir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tmpDir) // no-op after successful rename
+
+	if _, err := r.git(ctx, "init", tmpDir); err != nil {
+		return fmt.Errorf("git init: %w", err)
+	}
+
+	if _, err := r.git(ctx, "-C", tmpDir, "fetch", "--depth", "1", repoURL, sha); err != nil {
+		return fmt.Errorf("git fetch: %w", err)
+	}
+
+	if _, err := r.git(ctx, "-C", tmpDir, "checkout", "FETCH_HEAD"); err != nil {
+		return fmt.Errorf("git checkout: %w", err)
+	}
+
+	// Remove .git directory — we only need the working tree.
+	if err := os.RemoveAll(filepath.Join(tmpDir, ".git")); err != nil {
+		return fmt.Errorf("failed to remove .git directory: %w", err)
+	}
+
+	if err := os.Rename(tmpDir, destDir); err != nil {
+		return fmt.Errorf("failed to finalize cache entry: %w", err)
+	}
+
+	return nil
+}
+
+func (r *gitResolver) ContentHash(dir string) (string, error) {
+	h := sha256.New()
+
+	var paths []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.Type().IsRegular() {
+			rel, err := filepath.Rel(dir, path)
+			if err != nil {
+				return err
+			}
+
+			paths = append(paths, rel)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to walk directory: %w", err)
+	}
+
+	sort.Strings(paths)
+
+	for _, p := range paths {
+		// Include the path in the hash so renames are detected.
+		fmt.Fprintf(h, "path:%s\n", p)
+
+		data, err := os.ReadFile(filepath.Join(dir, p))
+		if err != nil {
+			return "", fmt.Errorf("failed to read file %s: %w", p, err)
+		}
+
+		h.Write(data)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// git runs a git command and returns its stdout.
+func (r *gitResolver) git(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, r.gitBin, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// toRepoURL converts a repo identifier to a git-cloneable URL.
+// Short-form identifiers (owner/repo) default to GitHub over HTTPS, which
+// works out of the box with credential helpers, PATs, and GitHub Actions
+// tokens without requiring SSH key configuration.
+func toRepoURL(repo string) string {
+	switch {
+	case strings.HasPrefix(repo, "https://"),
+		strings.HasPrefix(repo, "http://"),
+		strings.HasPrefix(repo, "git@"),
+		strings.HasPrefix(repo, "ssh://"),
+		strings.HasPrefix(repo, "file://"),
+		strings.HasPrefix(repo, "/"):
+		return repo
+	case strings.HasPrefix(repo, "github.com/"):
+		path := strings.TrimPrefix(repo, "github.com/")
+		return "https://github.com/" + path + ".git"
+	default:
+		return "https://github.com/" + repo + ".git"
+	}
+}
+
+// repoCacheKey converts a repo identifier to a filesystem-safe cache key.
+func repoCacheKey(repo string) string {
+	key := repo
+	key = strings.TrimPrefix(key, "https://")
+	key = strings.TrimPrefix(key, "http://")
+	key = strings.TrimPrefix(key, "git@")
+	key = strings.TrimPrefix(key, "ssh://")
+	key = strings.TrimPrefix(key, "file://")
+	key = strings.TrimSuffix(key, ".git")
+	key = strings.ReplaceAll(key, ":", "-")
+	key = strings.ReplaceAll(key, "/", "-")
+	return strings.Trim(key, "-")
+}

--- a/pkg/eval/tasksource/git_test.go
+++ b/pkg/eval/tasksource/git_test.go
@@ -1,0 +1,299 @@
+package tasksource
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+}
+
+// testGit runs a git command in dir and returns stdout. It sets dummy author
+// info so commits work in environments without global git config.
+func testGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=Test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, string(out))
+	return strings.TrimSpace(string(out))
+}
+
+// setupTestRepo creates a local bare repo containing the given files on a
+// "main" branch and returns the bare repo path and the commit SHA.
+func setupTestRepo(t *testing.T, files map[string]string) (bareDir, commitSHA string) {
+	t.Helper()
+
+	bareDir = t.TempDir()
+	testGit(t, bareDir, "init", "--bare")
+
+	workDir := t.TempDir()
+	testGit(t, workDir, "init")
+
+	for name, content := range files {
+		path := filepath.Join(workDir, name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	}
+
+	testGit(t, workDir, "add", "-A")
+	testGit(t, workDir, "commit", "-m", "initial commit")
+	testGit(t, workDir, "push", bareDir, "HEAD:refs/heads/main")
+
+	sha := testGit(t, workDir, "rev-parse", "HEAD")
+	return bareDir, sha
+}
+
+func TestToRepoURL(t *testing.T) {
+	tt := map[string]struct {
+		input    string
+		expected string
+	}{
+		"short form": {
+			input:    "owner/repo",
+			expected: "https://github.com/owner/repo.git",
+		},
+		"github.com prefix": {
+			input:    "github.com/owner/repo",
+			expected: "https://github.com/owner/repo.git",
+		},
+		"https url": {
+			input:    "https://github.com/owner/repo.git",
+			expected: "https://github.com/owner/repo.git",
+		},
+		"ssh url": {
+			input:    "git@github.com:owner/repo.git",
+			expected: "git@github.com:owner/repo.git",
+		},
+		"local path": {
+			input:    "/tmp/bare-repo",
+			expected: "/tmp/bare-repo",
+		},
+		"file url": {
+			input:    "file:///tmp/bare-repo",
+			expected: "file:///tmp/bare-repo",
+		},
+	}
+
+	for tn, tc := range tt {
+		t.Run(tn, func(t *testing.T) {
+			assert.Equal(t, tc.expected, toRepoURL(tc.input))
+		})
+	}
+}
+
+func TestRepoCacheKey(t *testing.T) {
+	tt := map[string]struct {
+		input    string
+		expected string
+	}{
+		"short form": {
+			input:    "owner/repo",
+			expected: "owner-repo",
+		},
+		"github.com prefix": {
+			input:    "github.com/owner/repo",
+			expected: "github.com-owner-repo",
+		},
+		"https url": {
+			input:    "https://github.com/owner/repo.git",
+			expected: "github.com-owner-repo",
+		},
+		"ssh url": {
+			input:    "git@github.com:owner/repo.git",
+			expected: "github.com-owner-repo",
+		},
+		"local path": {
+			input:    "/tmp/bare-repo",
+			expected: "tmp-bare-repo",
+		},
+	}
+
+	for tn, tc := range tt {
+		t.Run(tn, func(t *testing.T) {
+			assert.Equal(t, tc.expected, repoCacheKey(tc.input))
+		})
+	}
+}
+
+func TestResolve(t *testing.T) {
+	requireGit(t)
+
+	files := map[string]string{
+		"task.yaml":        "kind: Task\n",
+		"nested/other.yaml": "kind: Task\n",
+	}
+	bareDir, sha := setupTestRepo(t, files)
+	cacheDir := t.TempDir()
+
+	resolver, err := NewGitResolver(WithCacheDir(cacheDir))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Resolve by branch name — cache miss, should fetch.
+	dir, commit, err := resolver.Resolve(ctx, bareDir, "main")
+	require.NoError(t, err)
+	assert.Equal(t, sha, commit)
+	assert.DirExists(t, dir)
+	assert.FileExists(t, filepath.Join(dir, "task.yaml"))
+	assert.FileExists(t, filepath.Join(dir, "nested/other.yaml"))
+
+	// .git directory should not be present in the cached copy.
+	assert.NoDirExists(t, filepath.Join(dir, ".git"))
+}
+
+func TestResolve_BySHA(t *testing.T) {
+	requireGit(t)
+
+	bareDir, sha := setupTestRepo(t, map[string]string{"a.txt": "hello"})
+	cacheDir := t.TempDir()
+
+	resolver, err := NewGitResolver(WithCacheDir(cacheDir))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	dir, commit, err := resolver.Resolve(ctx, bareDir, sha)
+	require.NoError(t, err)
+	assert.Equal(t, sha, commit)
+
+	data, err := os.ReadFile(filepath.Join(dir, "a.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(data))
+}
+
+func TestResolve_CacheHit(t *testing.T) {
+	requireGit(t)
+
+	bareDir, sha := setupTestRepo(t, map[string]string{"f.txt": "data"})
+	cacheDir := t.TempDir()
+
+	resolver, err := NewGitResolver(WithCacheDir(cacheDir))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	dir1, _, err := resolver.Resolve(ctx, bareDir, "main")
+	require.NoError(t, err)
+
+	// Delete the bare repo so any network call would fail.
+	require.NoError(t, os.RemoveAll(bareDir))
+
+	// Resolve again using the SHA — ls-remote is skipped and the cache
+	// directory already exists, so this must succeed without network access.
+	dir2, commit2, err := resolver.Resolve(ctx, bareDir, sha)
+	require.NoError(t, err)
+	assert.Equal(t, dir1, dir2)
+	assert.Equal(t, sha, commit2)
+}
+
+func TestResolve_InvalidRef(t *testing.T) {
+	requireGit(t)
+
+	bareDir, _ := setupTestRepo(t, map[string]string{"f.txt": "x"})
+	cacheDir := t.TempDir()
+
+	resolver, err := NewGitResolver(WithCacheDir(cacheDir))
+	require.NoError(t, err)
+
+	_, _, err = resolver.Resolve(context.Background(), bareDir, "nonexistent-branch")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestResolve_InvalidRepo(t *testing.T) {
+	requireGit(t)
+
+	cacheDir := t.TempDir()
+	resolver, err := NewGitResolver(WithCacheDir(cacheDir))
+	require.NoError(t, err)
+
+	_, _, err = resolver.Resolve(context.Background(), "/nonexistent/repo/path", "main")
+	require.Error(t, err)
+}
+
+func TestContentHash(t *testing.T) {
+	requireGit(t)
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub/b.txt"), []byte("world"), 0o644))
+
+	resolver, err := NewGitResolver(WithCacheDir(t.TempDir()))
+	require.NoError(t, err)
+
+	hash1, err := resolver.ContentHash(dir)
+	require.NoError(t, err)
+	assert.Len(t, hash1, 64) // SHA-256 hex
+
+	// Same content produces the same hash.
+	hash2, err := resolver.ContentHash(dir)
+	require.NoError(t, err)
+	assert.Equal(t, hash1, hash2)
+
+	// Changing file content changes the hash.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("changed"), 0o644))
+	hash3, err := resolver.ContentHash(dir)
+	require.NoError(t, err)
+	assert.NotEqual(t, hash1, hash3)
+}
+
+func TestContentHash_RenameChangesHash(t *testing.T) {
+	requireGit(t)
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("same"), 0o644))
+
+	resolver, err := NewGitResolver(WithCacheDir(t.TempDir()))
+	require.NoError(t, err)
+
+	hash1, err := resolver.ContentHash(dir)
+	require.NoError(t, err)
+
+	// Rename the file — same content but different path should change the hash.
+	require.NoError(t, os.Rename(filepath.Join(dir, "a.txt"), filepath.Join(dir, "b.txt")))
+
+	hash2, err := resolver.ContentHash(dir)
+	require.NoError(t, err)
+	assert.NotEqual(t, hash1, hash2)
+}
+
+func TestContentHash_EmptyDir(t *testing.T) {
+	requireGit(t)
+
+	resolver, err := NewGitResolver(WithCacheDir(t.TempDir()))
+	require.NoError(t, err)
+
+	hash, err := resolver.ContentHash(t.TempDir())
+	require.NoError(t, err)
+	assert.Len(t, hash, 64)
+}
+
+func TestContentHash_NonexistentDir(t *testing.T) {
+	requireGit(t)
+
+	resolver, err := NewGitResolver(WithCacheDir(t.TempDir()))
+	require.NoError(t, err)
+
+	_, err = resolver.ContentHash("/nonexistent/dir")
+	require.Error(t, err)
+}

--- a/pkg/eval/tasksource/resolver.go
+++ b/pkg/eval/tasksource/resolver.go
@@ -1,0 +1,14 @@
+package tasksource
+
+import "context"
+
+// Resolver fetches external task sources and resolves them to local directories.
+type Resolver interface {
+	// Resolve fetches the source at the given repo and ref, returning the local
+	// directory path containing the task files and the resolved commit SHA.
+	Resolve(ctx context.Context, repo, ref string) (dir string, commit string, err error)
+
+	// ContentHash computes a SHA-256 hash of the source content at the given
+	// directory path, suitable for lockfile integrity verification.
+	ContentHash(dir string) (string, error)
+}


### PR DESCRIPTION
Resolves #281 

This PR adds a git TaskSource resolver. It uses the git CLI rather than fetching the tarball through the API (like I originally proposed in the issue) so that we can pick up on user git credentials