### PR TITLE
feat: add support for skills

### DIFF
--- a/examples/skills/eval.yaml
+++ b/examples/skills/eval.yaml
@@ -1,0 +1,16 @@
+kind: Eval
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  name: "skills-greeting"
+config:
+  agent:
+    type: "builtin.claude-code"
+  skills:
+    sources:
+      - type: path
+        path: ./skills/
+  taskSets:
+    - glob: tasks/*/*.yaml
+      assertions:
+        skillsLoaded:
+          - skill: "greeting"

--- a/examples/skills/skills/greeting/SKILL.md
+++ b/examples/skills/skills/greeting/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: greeting
+description: Generates a standardized greeting message. Always use when the user asks you to greet someone or introduce yourself.
+---
+
+When the user asks you to greet someone, always respond with:
+
+"Hello, {name}! Welcome to mcpchecker skills evaluation."
+
+Replace {name} with the name provided by the user. Always use this exact format.

--- a/examples/skills/tasks/use-greeting-skill/use-greeting-skill.yaml
+++ b/examples/skills/tasks/use-greeting-skill/use-greeting-skill.yaml
@@ -1,0 +1,8 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  name: "use-greeting-skill"
+  difficulty: easy
+spec:
+  prompt:
+    inline: Please greet Alice.

--- a/pkg/acpclient/acp.go
+++ b/pkg/acpclient/acp.go
@@ -104,18 +104,31 @@ func (c *client) SessionUpdate(ctx context.Context, params acp.SessionNotificati
 //
 // Only available if the client supports the 'fs.readTextFile' capability.
 func (c *client) ReadTextFile(ctx context.Context, params acp.ReadTextFileRequest) (acp.ReadTextFileResponse, error) {
-	if c.cwd == "" {
+	c.mu.RLock()
+	sess, ok := c.sessions[params.SessionId]
+	c.mu.RUnlock()
+
+	if !ok || sess.cwd == "" {
 		return acp.ReadTextFileResponse{}, fmt.Errorf("no fs.readTextFile capability")
 	}
+	cwd := sess.cwd
 
 	if !filepath.IsAbs(params.Path) {
 		return acp.ReadTextFileResponse{}, fmt.Errorf("path must be absolute: %s", params.Path)
 	}
 
-	// Security: scope reads to the agent's working directory
-	cleanPath := filepath.Clean(params.Path)
-	cwdPrefix := filepath.Clean(c.cwd) + string(filepath.Separator)
-	if !strings.HasPrefix(cleanPath, cwdPrefix) && cleanPath != filepath.Clean(c.cwd) {
+	// Security: scope reads to the agent's working directory.
+	// Resolve symlinks so a symlink inside cwd cannot escape the boundary.
+	cleanPath, err := filepath.EvalSymlinks(filepath.Clean(params.Path))
+	if err != nil {
+		return acp.ReadTextFileResponse{}, fmt.Errorf("resolve path %q: %w", params.Path, err)
+	}
+	resolvedCwd, err := filepath.EvalSymlinks(filepath.Clean(cwd))
+	if err != nil {
+		return acp.ReadTextFileResponse{}, fmt.Errorf("resolve working directory: %w", err)
+	}
+	cwdPrefix := resolvedCwd + string(filepath.Separator)
+	if !strings.HasPrefix(cleanPath, cwdPrefix) && cleanPath != resolvedCwd {
 		return acp.ReadTextFileResponse{}, fmt.Errorf("path %q is outside the agent working directory", params.Path)
 	}
 

--- a/pkg/acpclient/acp.go
+++ b/pkg/acpclient/acp.go
@@ -3,6 +3,9 @@ package acpclient
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/coder/acp-go-sdk"
 )
@@ -101,7 +104,45 @@ func (c *client) SessionUpdate(ctx context.Context, params acp.SessionNotificati
 //
 // Only available if the client supports the 'fs.readTextFile' capability.
 func (c *client) ReadTextFile(ctx context.Context, params acp.ReadTextFileRequest) (acp.ReadTextFileResponse, error) {
-	return acp.ReadTextFileResponse{}, fmt.Errorf("no fs.readTextFile capability")
+	if c.cwd == "" {
+		return acp.ReadTextFileResponse{}, fmt.Errorf("no fs.readTextFile capability")
+	}
+
+	if !filepath.IsAbs(params.Path) {
+		return acp.ReadTextFileResponse{}, fmt.Errorf("path must be absolute: %s", params.Path)
+	}
+
+	// Security: scope reads to the agent's working directory
+	cleanPath := filepath.Clean(params.Path)
+	cwdPrefix := filepath.Clean(c.cwd) + string(filepath.Separator)
+	if !strings.HasPrefix(cleanPath, cwdPrefix) && cleanPath != filepath.Clean(c.cwd) {
+		return acp.ReadTextFileResponse{}, fmt.Errorf("path %q is outside the agent working directory", params.Path)
+	}
+
+	b, err := os.ReadFile(cleanPath)
+	if err != nil {
+		return acp.ReadTextFileResponse{}, fmt.Errorf("read %s: %w", params.Path, err)
+	}
+
+	content := string(b)
+
+	// Apply optional line/limit (1-based line index)
+	if params.Line != nil || params.Limit != nil {
+		lines := strings.Split(content, "\n")
+		start := 0
+		if params.Line != nil && *params.Line > 0 {
+			start = min(max(*params.Line-1, 0), len(lines))
+		}
+		end := len(lines)
+		if params.Limit != nil && *params.Limit > 0 {
+			if start+*params.Limit < end {
+				end = start + *params.Limit
+			}
+		}
+		content = strings.Join(lines[start:end], "\n")
+	}
+
+	return acp.ReadTextFileResponse{Content: content}, nil
 }
 
 // Request to write content to a text file.

--- a/pkg/acpclient/acp_test.go
+++ b/pkg/acpclient/acp_test.go
@@ -185,5 +185,5 @@ func newTestSession(allowedTools []*mcp.Tool) *session {
 			&mockServer{name: "test-server", allowedTools: allowedTools},
 		},
 	}
-	return NewSession(mgr)
+	return NewSession(mgr, "")
 }

--- a/pkg/acpclient/client.go
+++ b/pkg/acpclient/client.go
@@ -53,7 +53,6 @@ type client struct {
 	cmd      *exec.Cmd
 	conn     *acp.ClientSideConnection
 	sessions map[acp.SessionId]*session
-	cwd      string // working directory for the current run, used by ReadTextFile
 }
 
 func (c *client) Start(ctx context.Context) error {
@@ -122,12 +121,8 @@ func (c *client) run(ctx context.Context, prompt string, servers mcpproxy.Server
 	}
 
 	defer func() {
-		c.cwd = ""
 		_ = os.RemoveAll(tmpDir)
 	}()
-
-	// Store cwd for ReadTextFile callback
-	c.cwd = tmpDir
 
 	// Mount skills into the temp directory if configured
 	if c.skills != nil {
@@ -171,7 +166,7 @@ func (c *client) run(ctx context.Context, prompt string, servers mcpproxy.Server
 
 	// store the session
 	c.mu.Lock()
-	c.sessions[session.SessionId] = NewSession(servers)
+	c.sessions[session.SessionId] = NewSession(servers, tmpDir)
 	c.mu.Unlock()
 
 	// this runs the current prompt to completion

--- a/pkg/acpclient/client.go
+++ b/pkg/acpclient/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mcpchecker/mcpchecker/pkg/mcpclient"
 	"github.com/mcpchecker/mcpchecker/pkg/mcpproxy"
 	"github.com/mcpchecker/mcpchecker/pkg/tokens"
+	"github.com/mcpchecker/mcpchecker/pkg/util"
 )
 
 // RunResult contains the results of running a prompt, including session updates
@@ -33,19 +34,26 @@ type Client interface {
 	Close(ctx context.Context) error
 }
 
-func NewClient(ctx context.Context, cfg *AcpConfig) Client {
+func NewClient(ctx context.Context, cfg *AcpConfig, opts ...ClientOption) Client {
+	var o clientOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
 	return &client{
 		cfg:      cfg,
+		skills:   o.skills,
 		sessions: make(map[acp.SessionId]*session),
 	}
 }
 
 type client struct {
 	cfg      *AcpConfig
+	skills   SkillInfo
 	mu       sync.RWMutex
 	cmd      *exec.Cmd
 	conn     *acp.ClientSideConnection
 	sessions map[acp.SessionId]*session
+	cwd      string // working directory for the current run, used by ReadTextFile
 }
 
 func (c *client) Start(ctx context.Context) error {
@@ -56,10 +64,11 @@ func (c *client) Start(ctx context.Context) error {
 
 	c.conn = acp.NewClientSideConnection(c, stdin, stdout)
 
+	enableReadFile := c.skills != nil && len(c.skills.GetSourceDirs()) > 0
 	initResp, err := c.conn.Initialize(ctx, acp.InitializeRequest{
 		ProtocolVersion: acp.ProtocolVersionNumber,
 		ClientCapabilities: acp.ClientCapabilities{
-			Fs:       acp.FileSystemCapabilities{ReadTextFile: false, WriteTextFile: false},
+			Fs:       acp.FileSystemCapabilities{ReadTextFile: enableReadFile, WriteTextFile: false},
 			Terminal: false,
 		},
 	})
@@ -113,29 +122,43 @@ func (c *client) run(ctx context.Context, prompt string, servers mcpproxy.Server
 	}
 
 	defer func() {
+		c.cwd = ""
 		_ = os.RemoveAll(tmpDir)
 	}()
 
-	mcpServers := make([]acp.McpServer, 0, len(servers.GetMcpServers()))
-	for _, srv := range servers.GetMcpServers() {
-		cfg, err := srv.GetConfig()
-		if err != nil {
-			return nil, acp.PromptResponse{}, fmt.Errorf("failed to get config for mcp server %q: %w", srv.GetName(), err)
-		}
+	// Store cwd for ReadTextFile callback
+	c.cwd = tmpDir
 
-		headers := make([]acp.HttpHeader, 0, len(cfg.Headers))
-		for k, v := range cfg.Headers {
-			headers = append(headers, acp.HttpHeader{Name: k, Value: v})
+	// Mount skills into the temp directory if configured
+	if c.skills != nil {
+		if err := util.MountSkills(tmpDir, c.skills.GetMountPath(), c.skills.GetSourceDirs()); err != nil {
+			return nil, acp.PromptResponse{}, fmt.Errorf("failed to mount skills: %w", err)
 		}
+	}
 
-		mcpServers = append(mcpServers, acp.McpServer{
-			Http: &acp.McpServerHttpInline{
-				Name:    srv.GetName(),
-				Url:     cfg.URL,
-				Type:    mcpclient.TransportTypeHttp,
-				Headers: headers,
-			},
-		})
+	var mcpServers []acp.McpServer
+	if servers != nil {
+		mcpServers = make([]acp.McpServer, 0, len(servers.GetMcpServers()))
+		for _, srv := range servers.GetMcpServers() {
+			cfg, err := srv.GetConfig()
+			if err != nil {
+				return nil, acp.PromptResponse{}, fmt.Errorf("failed to get config for mcp server %q: %w", srv.GetName(), err)
+			}
+
+			headers := make([]acp.HttpHeader, 0, len(cfg.Headers))
+			for k, v := range cfg.Headers {
+				headers = append(headers, acp.HttpHeader{Name: k, Value: v})
+			}
+
+			mcpServers = append(mcpServers, acp.McpServer{
+				Http: &acp.McpServerHttpInline{
+					Name:    srv.GetName(),
+					Url:     cfg.URL,
+					Type:    mcpclient.TransportTypeHttp,
+					Headers: headers,
+				},
+			})
+		}
 	}
 
 	session, err := c.conn.NewSession(ctx, acp.NewSessionRequest{

--- a/pkg/acpclient/config.go
+++ b/pkg/acpclient/config.go
@@ -25,3 +25,24 @@ type AcpConfig struct {
 	// This allows in-memory communication with an agent.
 	Transport Transport `json:"-"`
 }
+
+// SkillInfo provides skill mounting information for ACP agents.
+// Implemented by agent.SkillInfo to avoid import cycles.
+type SkillInfo interface {
+	GetMountPath() string
+	GetSourceDirs() []string
+}
+
+// ClientOption configures optional behavior for the ACP client.
+type ClientOption func(*clientOptions)
+
+type clientOptions struct {
+	skills SkillInfo
+}
+
+// WithSkills configures skill mounting for the ACP client.
+func WithSkills(skills SkillInfo) ClientOption {
+	return func(o *clientOptions) {
+		o.skills = skills
+	}
+}

--- a/pkg/acpclient/session.go
+++ b/pkg/acpclient/session.go
@@ -11,13 +11,15 @@ import (
 
 type session struct {
 	mu               sync.Mutex
+	cwd              string // working directory for this session, used by ReadTextFile
 	updates          []acp.SessionUpdate // track all the updates in a json serializable way for future analysis
 	toolCallStatuses map[acp.ToolCallId]*acp.SessionToolCallUpdate
 	mcpServers       mcpproxy.ServerManager
 }
 
-func NewSession(mcpServers mcpproxy.ServerManager) *session {
+func NewSession(mcpServers mcpproxy.ServerManager, cwd string) *session {
 	return &session{
+		cwd:              cwd,
 		updates:          make([]acp.SessionUpdate, 0),
 		toolCallStatuses: make(map[acp.ToolCallId]*acp.SessionToolCallUpdate),
 		mcpServers:       mcpServers,

--- a/pkg/acpclient/session_test.go
+++ b/pkg/acpclient/session_test.go
@@ -87,7 +87,7 @@ func TestSession_IsAllowedToolCall(t *testing.T) {
 					&mockServer{name: "test-server", allowedTools: tc.allowedTools},
 				},
 			}
-			s := NewSession(mgr)
+			s := NewSession(mgr, "")
 
 			result := s.isAllowedToolCall(context.Background(), tc.call)
 			assert.Equal(t, tc.expected, result)
@@ -102,7 +102,7 @@ func TestSession_IsAllowedToolCall_WithPriorUpdate(t *testing.T) {
 			&mockServer{name: "test-server", allowedTools: []*mcp.Tool{{Name: "read_file", Title: "Read File"}}},
 		},
 	}
-	s := NewSession(mgr)
+	s := NewSession(mgr, "")
 
 	// First, store a tool call with a title
 	s.toolCallStatuses["call-1"] = &acp.SessionToolCallUpdate{
@@ -171,7 +171,7 @@ func TestSession_ToolCallStatusUpdateLocked(t *testing.T) {
 	for tn, tc := range tt {
 		t.Run(tn, func(t *testing.T) {
 			mgr := &mockServerManager{}
-			s := NewSession(mgr)
+			s := NewSession(mgr, "")
 
 			if tc.initial != nil {
 				s.toolCallStatuses[tc.initial.ToolCallId] = tc.initial
@@ -306,7 +306,7 @@ func TestSession_IsAllowedToolCall_FuzzyMatching(t *testing.T) {
 					&mockServer{name: tc.serverName, allowedTools: tc.allowedTools},
 				},
 			}
-			s := NewSession(mgr)
+			s := NewSession(mgr, "")
 
 			call := acp.ToolCallUpdate{
 				ToolCallId: "call-1",

--- a/pkg/agent/acp_runner.go
+++ b/pkg/agent/acp_runner.go
@@ -12,6 +12,7 @@ type acpRunner struct {
 	name       string
 	cfg        *acpclient.AcpConfig
 	mcpServers mcpproxy.ServerManager
+	skills     *SkillInfo
 }
 
 var _ Runner = &acpRunner{}
@@ -24,7 +25,7 @@ func NewAcpRunner(cfg *acpclient.AcpConfig, name string) Runner {
 }
 
 func (r *acpRunner) RunTask(ctx context.Context, prompt string) (AgentResult, error) {
-	client := acpclient.NewClient(ctx, r.cfg)
+	client := acpclient.NewClient(ctx, r.cfg, r.skills.ClientOptions()...)
 	defer client.Close(ctx)
 
 	err := client.Start(ctx)
@@ -49,6 +50,16 @@ func (r *acpRunner) WithMcpServerInfo(mcpServers mcpproxy.ServerManager) Runner 
 		name:       r.name,
 		cfg:        r.cfg,
 		mcpServers: mcpServers,
+		skills:     r.skills,
+	}
+}
+
+func (r *acpRunner) WithSkillInfo(skills *SkillInfo) Runner {
+	return &acpRunner{
+		name:       r.name,
+		cfg:        r.cfg,
+		mcpServers: r.mcpServers,
+		skills:     skills,
 	}
 }
 

--- a/pkg/agent/claude_code.go
+++ b/pkg/agent/claude_code.go
@@ -36,5 +36,9 @@ func (a *ClaudeCodeAgent) GetDefaults(model string) (*AgentSpec, error) {
 		AcpConfig: &acpclient.AcpConfig{
 			Cmd: "claude-agent-acp",
 		},
+		Skills: &AgentSkillsConfig{
+			MountPath: ".claude/skills",
+			ToolName:  "Skill",
+		},
 	}, nil
 }

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -114,6 +114,15 @@ func Read(data []byte) (*AgentSpec, error) {
 		return nil, err
 	}
 
+	if spec.Skills != nil {
+		if spec.Skills.MountPath == "" {
+			return nil, fmt.Errorf("skills.mountPath is required when skills are configured")
+		}
+		if spec.Skills.ToolName == "" {
+			return nil, fmt.Errorf("skills.toolName is required when skills are configured")
+		}
+	}
+
 	return spec, nil
 }
 

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -19,6 +19,18 @@ type AgentSpec struct {
 	Builtin       *BuiltinRef          `json:"builtin,omitempty"`
 	AcpConfig     *acpclient.AcpConfig `json:"acp,omitempty"` // if builtin and acp are both set, default to acp
 	Commands      AgentCommands        `json:"commands"`
+	Skills        *AgentSkillsConfig   `json:"skills,omitempty"`
+}
+
+// AgentSkillsConfig defines agent-specific skill loading behavior
+type AgentSkillsConfig struct {
+	// MountPath is the relative path within the agent's working directory
+	// where skill files should be placed (e.g., ".claude/skills" for Claude Code)
+	MountPath string `json:"mountPath"`
+
+	// ToolName is the agent-specific tool name used to load skills
+	// (e.g., "Skill" for Claude Code)
+	ToolName string `json:"toolName"`
 }
 
 // AgentRef specifies how to configure the agent

--- a/pkg/agent/llm_acp_runner.go
+++ b/pkg/agent/llm_acp_runner.go
@@ -16,6 +16,7 @@ import (
 type llmACPRunner struct {
 	model      string
 	mcpServers mcpproxy.ServerManager
+	skills     *SkillInfo
 }
 
 var _ Runner = &llmACPRunner{}
@@ -40,6 +41,15 @@ func (r *llmACPRunner) WithMcpServerInfo(mcpServers mcpproxy.ServerManager) Runn
 	return &llmACPRunner{
 		model:      r.model,
 		mcpServers: mcpServers,
+		skills:     r.skills,
+	}
+}
+
+func (r *llmACPRunner) WithSkillInfo(skills *SkillInfo) Runner {
+	return &llmACPRunner{
+		model:      r.model,
+		mcpServers: r.mcpServers,
+		skills:     skills,
 	}
 }
 
@@ -53,7 +63,7 @@ func (r *llmACPRunner) RunTask(ctx context.Context, prompt string) (AgentResult,
 
 	client := acpclient.NewClient(ctx, &acpclient.AcpConfig{
 		Transport: transport,
-	})
+	}, r.skills.ClientOptions()...)
 
 	if err := client.Start(ctx); err != nil {
 		return nil, fmt.Errorf("failed to start ACP client: %w", err)

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -10,15 +10,42 @@ import (
 	"text/template"
 
 	"github.com/coder/acp-go-sdk"
+	"github.com/mcpchecker/mcpchecker/pkg/acpclient"
 	"github.com/mcpchecker/mcpchecker/pkg/mcpproxy"
 	"github.com/mcpchecker/mcpchecker/pkg/tokenizer"
 	"github.com/mcpchecker/mcpchecker/pkg/tokens"
+	"github.com/mcpchecker/mcpchecker/pkg/util"
 )
 
 type Runner interface {
 	RunTask(ctx context.Context, prompt string) (AgentResult, error)
 	WithMcpServerInfo(mcpServers mcpproxy.ServerManager) Runner
+	WithSkillInfo(skills *SkillInfo) Runner
 	AgentName() string
+}
+
+// SkillInfo contains skill mounting information for the agent runner.
+// Implements acpclient.SkillInfo.
+type SkillInfo struct {
+	// MountPath is the relative path within the agent's working directory
+	// where skill files should be placed (e.g., ".claude/skills")
+	MountPath string
+
+	// SourceDirs contains absolute paths to skill source directories
+	// whose contents will be copied into the mount path
+	SourceDirs []string
+}
+
+func (s *SkillInfo) GetMountPath() string    { return s.MountPath }
+func (s *SkillInfo) GetSourceDirs() []string { return s.SourceDirs }
+
+// ClientOptions returns ACP client options for skill mounting.
+// Safe to call on a nil receiver (returns nil).
+func (s *SkillInfo) ClientOptions() []acpclient.ClientOption {
+	if s == nil {
+		return nil
+	}
+	return []acpclient.ClientOption{acpclient.WithSkills(s)}
 }
 
 type McpServerInfo interface {
@@ -339,6 +366,7 @@ type AgentResult interface {
 type agentSpecRunner struct {
 	*AgentSpec
 	mcpInfo McpServerInfo
+	skills  *SkillInfo
 }
 
 type agentSpecRunnerResult struct {
@@ -466,6 +494,13 @@ func (a *agentSpecRunner) RunTask(ctx context.Context, prompt string) (AgentResu
 			fmt.Fprintf(os.Stderr, "Preserving temporary directory %s because %s\n", tempDir, reason)
 		}
 	}()
+
+	// Mount skills into the temp directory if configured
+	if a.skills != nil {
+		if err := util.MountSkills(tempDir, a.skills.MountPath, a.skills.SourceDirs); err != nil {
+			return nil, fmt.Errorf("failed to mount skills: %w", err)
+		}
+	}
 
 	argTemplateMcpServer, err := template.New("argTemplateMcpServer").Parse(a.Commands.ArgTemplateMcpServer)
 	if err != nil {
@@ -606,6 +641,15 @@ func (a *agentSpecRunner) WithMcpServerInfo(mcpServers mcpproxy.ServerManager) R
 	return &agentSpecRunner{
 		AgentSpec: a.AgentSpec,
 		mcpInfo:   mcpServers,
+		skills:    a.skills,
+	}
+}
+
+func (a *agentSpecRunner) WithSkillInfo(skills *SkillInfo) Runner {
+	return &agentSpecRunner{
+		AgentSpec: a.AgentSpec,
+		mcpInfo:   a.mcpInfo,
+		skills:    skills,
 	}
 }
 

--- a/pkg/eval/assert.go
+++ b/pkg/eval/assert.go
@@ -802,11 +802,11 @@ func evaluateSkillsNotLoaded(assertions []SkillAssertion, toolCalls []agent.Tool
 	return &SingleAssertionResult{Passed: true}
 }
 
-// matchesSkillAssertion checks if the serialized tool call input matches a skill assertion.
-// For exact match (Skill field): checks if the skill name appears as a substring in the input.
+// matchesSkillAssertion checks if the serialized JSON tool call input matches a skill assertion.
+// For exact match (Skill field): checks if the skill name appears as a JSON-quoted string in the input.
 // For pattern match (SkillPattern field): matches the regex against the input.
 func matchesSkillAssertion(serializedInput string, assertion SkillAssertion) bool {
-	if assertion.Skill != "" && strings.Contains(serializedInput, assertion.Skill) {
+	if assertion.Skill != "" && strings.Contains(serializedInput, "\""+assertion.Skill+"\"") {
 		return true
 	}
 

--- a/pkg/eval/assert.go
+++ b/pkg/eval/assert.go
@@ -1,11 +1,14 @@
 package eval
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
+	"strings"
 	"time"
 
+	"github.com/mcpchecker/mcpchecker/pkg/agent"
 	"github.com/mcpchecker/mcpchecker/pkg/mcpproxy"
 )
 
@@ -49,50 +52,38 @@ type CompositeAssertionResult struct {
 	PromptsNotUsed   *SingleAssertionResult `json:"promptsNotUsed,omitempty"`
 	CallOrder        *SingleAssertionResult `json:"callOrder,omitempty"`
 	NoDuplicateCalls *SingleAssertionResult `json:"noDuplicateCalls,omitempty"`
+	SkillsLoaded     *SingleAssertionResult `json:"skillsLoaded,omitempty"`
+	SkillsNotLoaded  *SingleAssertionResult `json:"skillsNotLoaded,omitempty"`
+}
+
+// allFields returns all assertion result pointers for iteration.
+// Update this method when adding new assertion types.
+func (c *CompositeAssertionResult) allFields() []*SingleAssertionResult {
+	return []*SingleAssertionResult{
+		c.ToolsUsed, c.RequireAny, c.ToolsNotUsed,
+		c.MinToolCalls, c.MaxToolCalls, c.ResourcesRead,
+		c.ResourcesNotRead, c.PromptsUsed, c.PromptsNotUsed,
+		c.CallOrder, c.NoDuplicateCalls,
+		c.SkillsLoaded, c.SkillsNotLoaded,
+	}
 }
 
 func (c *CompositeAssertionResult) Succeeded() bool {
-	return c.ToolsUsed.Succeeded() && c.RequireAny.Succeeded() && c.ToolsNotUsed.Succeeded() &&
-		c.MinToolCalls.Succeeded() && c.MaxToolCalls.Succeeded() && c.ResourcesRead.Succeeded() &&
-		c.ResourcesNotRead.Succeeded() && c.PromptsUsed.Succeeded() && c.PromptsNotUsed.Succeeded() &&
-		c.CallOrder.Succeeded() && c.NoDuplicateCalls.Succeeded()
+	for _, f := range c.allFields() {
+		if !f.Succeeded() {
+			return false
+		}
+	}
+	return true
 }
 
 // TotalAssertions returns the total number of individual assertions that were evaluated
 func (c *CompositeAssertionResult) TotalAssertions() int {
 	count := 0
-	if c.ToolsUsed != nil {
-		count++
-	}
-	if c.RequireAny != nil {
-		count++
-	}
-	if c.ToolsNotUsed != nil {
-		count++
-	}
-	if c.MinToolCalls != nil {
-		count++
-	}
-	if c.MaxToolCalls != nil {
-		count++
-	}
-	if c.ResourcesRead != nil {
-		count++
-	}
-	if c.ResourcesNotRead != nil {
-		count++
-	}
-	if c.PromptsUsed != nil {
-		count++
-	}
-	if c.PromptsNotUsed != nil {
-		count++
-	}
-	if c.CallOrder != nil {
-		count++
-	}
-	if c.NoDuplicateCalls != nil {
-		count++
+	for _, f := range c.allFields() {
+		if f != nil {
+			count++
+		}
 	}
 	return count
 }
@@ -100,38 +91,10 @@ func (c *CompositeAssertionResult) TotalAssertions() int {
 // PassedAssertions returns the number of individual assertions that passed
 func (c *CompositeAssertionResult) PassedAssertions() int {
 	count := 0
-	if c.ToolsUsed != nil && c.ToolsUsed.Succeeded() {
-		count++
-	}
-	if c.RequireAny != nil && c.RequireAny.Succeeded() {
-		count++
-	}
-	if c.ToolsNotUsed != nil && c.ToolsNotUsed.Succeeded() {
-		count++
-	}
-	if c.MinToolCalls != nil && c.MinToolCalls.Succeeded() {
-		count++
-	}
-	if c.MaxToolCalls != nil && c.MaxToolCalls.Succeeded() {
-		count++
-	}
-	if c.ResourcesRead != nil && c.ResourcesRead.Succeeded() {
-		count++
-	}
-	if c.ResourcesNotRead != nil && c.ResourcesNotRead.Succeeded() {
-		count++
-	}
-	if c.PromptsUsed != nil && c.PromptsUsed.Succeeded() {
-		count++
-	}
-	if c.PromptsNotUsed != nil && c.PromptsNotUsed.Succeeded() {
-		count++
-	}
-	if c.CallOrder != nil && c.CallOrder.Succeeded() {
-		count++
-	}
-	if c.NoDuplicateCalls != nil && c.NoDuplicateCalls.Succeeded() {
-		count++
+	for _, f := range c.allFields() {
+		if f != nil && f.Succeeded() {
+			count++
+		}
 	}
 	return count
 }
@@ -774,5 +737,83 @@ func (c *CompositeAssertionResult) Merge(other *CompositeAssertionResult) *Compo
 		PromptsNotUsed:   mergeField(c.PromptsNotUsed, other.PromptsNotUsed),
 		CallOrder:        mergeField(c.CallOrder, other.CallOrder),
 		NoDuplicateCalls: mergeField(c.NoDuplicateCalls, other.NoDuplicateCalls),
+		SkillsLoaded:     mergeField(c.SkillsLoaded, other.SkillsLoaded),
+		SkillsNotLoaded:  mergeField(c.SkillsNotLoaded, other.SkillsNotLoaded),
 	}
+}
+
+// collectSkillInputs returns serialized tool call inputs for calls matching toolName.
+func collectSkillInputs(toolCalls []agent.ToolCallSummary, toolName string) []string {
+	var inputs []string
+	for _, tc := range toolCalls {
+		if tc.Title == toolName {
+			if tc.RawInput == nil {
+				continue
+			}
+			if b, err := json.Marshal(tc.RawInput); err == nil {
+				inputs = append(inputs, string(b))
+			}
+		}
+	}
+	return inputs
+}
+
+// evaluateSkillsLoaded checks that all required skills were loaded by the agent.
+func evaluateSkillsLoaded(assertions []SkillAssertion, toolCalls []agent.ToolCallSummary, toolName string) *SingleAssertionResult {
+	skillInputs := collectSkillInputs(toolCalls, toolName)
+
+	for _, assertion := range assertions {
+		found := false
+		for _, input := range skillInputs {
+			if matchesSkillAssertion(input, assertion) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return &SingleAssertionResult{
+				Passed: false,
+				Reason: fmt.Sprintf("Required skill not loaded: skill=%s, pattern=%s",
+					assertion.Skill, assertion.SkillPattern),
+			}
+		}
+	}
+
+	return &SingleAssertionResult{Passed: true}
+}
+
+// evaluateSkillsNotLoaded checks that no forbidden skills were loaded by the agent.
+func evaluateSkillsNotLoaded(assertions []SkillAssertion, toolCalls []agent.ToolCallSummary, toolName string) *SingleAssertionResult {
+	skillInputs := collectSkillInputs(toolCalls, toolName)
+
+	for _, assertion := range assertions {
+		for _, input := range skillInputs {
+			if matchesSkillAssertion(input, assertion) {
+				return &SingleAssertionResult{
+					Passed: false,
+					Reason: fmt.Sprintf("Forbidden skill was loaded: skill=%s, pattern=%s",
+						assertion.Skill, assertion.SkillPattern),
+				}
+			}
+		}
+	}
+
+	return &SingleAssertionResult{Passed: true}
+}
+
+// matchesSkillAssertion checks if the serialized tool call input matches a skill assertion.
+// For exact match (Skill field): checks if the skill name appears as a substring in the input.
+// For pattern match (SkillPattern field): matches the regex against the input.
+func matchesSkillAssertion(serializedInput string, assertion SkillAssertion) bool {
+	if assertion.Skill != "" && strings.Contains(serializedInput, assertion.Skill) {
+		return true
+	}
+
+	if assertion.SkillPattern != "" {
+		matched, _ := regexp.MatchString(assertion.SkillPattern, serializedInput)
+		return matched
+	}
+
+	return false
 }

--- a/pkg/eval/assert_test.go
+++ b/pkg/eval/assert_test.go
@@ -1709,3 +1709,54 @@ func TestNewCompositeAssertionEvaluator(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchesSkillAssertion(t *testing.T) {
+	tt := map[string]struct {
+		input     string
+		assertion SkillAssertion
+		expected  bool
+	}{
+		"exact match with quoted skill name": {
+			input:     `{"skill":"greet","args":{}}`,
+			assertion: SkillAssertion{Skill: "greet"},
+			expected:  true,
+		},
+		"no match on prefix substring": {
+			input:     `{"skill":"greet_user","args":{}}`,
+			assertion: SkillAssertion{Skill: "greet"},
+			expected:  false,
+		},
+		"no match on suffix substring": {
+			input:     `{"skill":"my_greet","args":{}}`,
+			assertion: SkillAssertion{Skill: "greet"},
+			expected:  false,
+		},
+		"no match on infix substring": {
+			input:     `{"skill":"my_greet_user","args":{}}`,
+			assertion: SkillAssertion{Skill: "greet"},
+			expected:  false,
+		},
+		"pattern match works": {
+			input:     `{"skill":"greet_user","args":{}}`,
+			assertion: SkillAssertion{SkillPattern: "greet.*"},
+			expected:  true,
+		},
+		"pattern no match": {
+			input:     `{"skill":"hello","args":{}}`,
+			assertion: SkillAssertion{SkillPattern: "greet.*"},
+			expected:  false,
+		},
+		"empty assertion matches nothing": {
+			input:     `{"skill":"greet","args":{}}`,
+			assertion: SkillAssertion{},
+			expected:  false,
+		},
+	}
+
+	for tn, tc := range tt {
+		t.Run(tn, func(t *testing.T) {
+			result := matchesSkillAssertion(tc.input, tc.assertion)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/pkg/eval/config.go
+++ b/pkg/eval/config.go
@@ -51,12 +51,30 @@ type EvalConfig struct {
 	McpConfigFile string                       `json:"mcpConfigFile"`
 	LLMJudge      *llmjudge.LLMJudgeEvalConfig `json:"llmJudge"`
 
+	// Skills configuration - defines skill sources to mount for the agent
+	Skills *SkillsConfig `json:"skills,omitempty"`
+
 	// DefaultTaskLimits sets default timeout limits for all tasks in this eval.
 	// Individual tasks can override these via spec.limits.
 	DefaultTaskLimits *util.Limits `json:"defaultTaskLimits,omitempty"`
 
 	// Advanced mode: different assertion sets
 	TaskSets []TaskSet `json:"taskSets,omitempty"`
+}
+
+// SkillsConfig defines skill sources to mount for agent evaluation
+type SkillsConfig struct {
+	// Sources is a list of skill sources to mount
+	Sources []SkillSource `json:"sources"`
+}
+
+// SkillSource defines where to find skill files
+type SkillSource struct {
+	// Type is the source type ("path" for now)
+	Type string `json:"type"`
+
+	// Path to a local directory containing skill files (used when type is "path")
+	Path string `json:"path,omitempty"`
 }
 
 // SourceSpec defines a cross-repo eval source
@@ -104,6 +122,20 @@ type TaskAssertions struct {
 
 	// Efficiency assertions
 	NoDuplicateCalls bool `json:"noDuplicateCalls,omitempty"`
+
+	// Skill assertions - evaluated against agent tool calls
+	SkillsLoaded    []SkillAssertion `json:"skillsLoaded,omitempty"`
+	SkillsNotLoaded []SkillAssertion `json:"skillsNotLoaded,omitempty"`
+}
+
+// SkillAssertion identifies a skill by name or pattern for assertion matching.
+// Matching is done by searching the serialized RawInput of agent tool calls
+// whose Title matches the configured skill tool name.
+type SkillAssertion struct {
+	// Skill is the exact skill name to match (substring match in tool call input)
+	Skill string `json:"skill,omitempty"`
+	// SkillPattern is a regex pattern to match against tool call input
+	SkillPattern string `json:"skillPattern,omitempty"`
 }
 
 type ToolAssertion struct {
@@ -168,6 +200,18 @@ func Read(data []byte, basePath string) (*EvalSpec, error) {
 	for name, src := range spec.Config.Sources {
 		if err := validateSourceSpec(name, src); err != nil {
 			return nil, err
+		}
+	}
+
+	// Resolve skill source paths
+	if spec.Config.Skills != nil {
+		for i := range spec.Config.Skills.Sources {
+			src := &spec.Config.Skills.Sources[i]
+			if src.Type == "path" {
+				if err := resolveFilePath(&src.Path, basePath); err != nil {
+					return nil, fmt.Errorf("failed to resolve skill source path at index %d: %w", i, err)
+				}
+			}
 		}
 	}
 

--- a/pkg/eval/config.go
+++ b/pkg/eval/config.go
@@ -132,7 +132,7 @@ type TaskAssertions struct {
 // Matching is done by searching the serialized RawInput of agent tool calls
 // whose Title matches the configured skill tool name.
 type SkillAssertion struct {
-	// Skill is the exact skill name to match (substring match in tool call input)
+	// Skill is the exact skill name to match (quoted string match in serialized tool call input)
 	Skill string `json:"skill,omitempty"`
 	// SkillPattern is a regex pattern to match against tool call input
 	SkillPattern string `json:"skillPattern,omitempty"`
@@ -203,14 +203,21 @@ func Read(data []byte, basePath string) (*EvalSpec, error) {
 		}
 	}
 
-	// Resolve skill source paths
+	// Resolve and validate skill source paths
 	if spec.Config.Skills != nil {
 		for i := range spec.Config.Skills.Sources {
 			src := &spec.Config.Skills.Sources[i]
-			if src.Type == "path" {
-				if err := resolveFilePath(&src.Path, basePath); err != nil {
-					return nil, fmt.Errorf("failed to resolve skill source path at index %d: %w", i, err)
-				}
+			if src.Type == "" {
+				return nil, fmt.Errorf("skills.sources[%d]: type is required", i)
+			}
+			if src.Type != "path" {
+				return nil, fmt.Errorf("skills.sources[%d]: unsupported type %q (must be \"path\")", i, src.Type)
+			}
+			if src.Path == "" {
+				return nil, fmt.Errorf("skills.sources[%d]: path is required for type \"path\"", i)
+			}
+			if err := resolveFilePath(&src.Path, basePath); err != nil {
+				return nil, fmt.Errorf("failed to resolve skill source path at index %d: %w", i, err)
 			}
 		}
 	}

--- a/pkg/eval/output.go
+++ b/pkg/eval/output.go
@@ -14,10 +14,17 @@ type EvalSummary struct {
 	Agent           *AgentSummary      `json:"agent"`
 	Judge           *JudgeSummary      `json:"judge,omitempty"`
 	MCPServers      []MCPServerSummary `json:"mcpServers,omitempty"`
+	Skills          []SkillSummary     `json:"skills,omitempty"`
 	Evals           *EvalsSummary      `json:"evals"`
 	Timeout         *TimeoutSummary    `json:"timeout,omitempty"`
 	ParallelWorkers int                `json:"parallelWorkers"`
 	Runs            int                `json:"runs"`
+}
+
+// SkillSummary describes a configured skill source.
+type SkillSummary struct {
+	Type string `json:"type"`
+	Path string `json:"path,omitempty"`
 }
 
 // AgentSummary describes the agent configuration.

--- a/pkg/eval/runner.go
+++ b/pkg/eval/runner.go
@@ -199,6 +199,9 @@ func (r *evalRunner) RunWithProgress(ctx context.Context, taskPattern string, ca
 	}
 
 	// Wire skills into the agent runner if configured
+	if r.spec.Config.Skills != nil && agentSpec.Skills == nil {
+		return nil, fmt.Errorf("eval config defines skills but agent %q has no skills configuration", agentSpec.Metadata.Name)
+	}
 	if r.spec.Config.Skills != nil && agentSpec.Skills != nil {
 		r.skillToolName = agentSpec.Skills.ToolName
 

--- a/pkg/eval/runner.go
+++ b/pkg/eval/runner.go
@@ -78,6 +78,7 @@ type evalRunner struct {
 	parallelWorkers   int
 	runs              int
 	runsExplicitlySet bool
+	skillToolName     string // agent-specific tool name for skill assertions (e.g., "Skill")
 
 	// Timeout overrides from CLI
 	defaultTaskTimeout    string
@@ -150,8 +151,8 @@ func (r *evalRunner) loadMcpConfig() (*mcpclient.MCPConfig, error) {
 		return config, nil
 	}
 
-	// Neither available
-	return nil, fmt.Errorf("no MCP configuration found: specify mcpConfigFile in eval config or set MCP_URL/MCP_COMMAND environment variables")
+	// Neither available — this is OK if skills are configured
+	return nil, nil
 }
 
 func (r *evalRunner) loadAgentSpec() (*agent.AgentSpec, error) {
@@ -183,6 +184,10 @@ func (r *evalRunner) RunWithProgress(ctx context.Context, taskPattern string, ca
 		return nil, err
 	}
 
+	if mcpConfig == nil && r.spec.Config.Skills == nil {
+		return nil, fmt.Errorf("at least one of MCP config or skills must be configured")
+	}
+
 	agentSpec, err := r.loadAgentSpec()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load agent spec: %w", err)
@@ -191,6 +196,25 @@ func (r *evalRunner) RunWithProgress(ctx context.Context, taskPattern string, ca
 	runner, err := agent.NewRunnerForSpec(agentSpec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create agent runner from spec: %w", err)
+	}
+
+	// Wire skills into the agent runner if configured
+	if r.spec.Config.Skills != nil && agentSpec.Skills != nil {
+		r.skillToolName = agentSpec.Skills.ToolName
+
+		var sourceDirs []string
+		for _, src := range r.spec.Config.Skills.Sources {
+			if src.Type == "path" {
+				sourceDirs = append(sourceDirs, src.Path)
+			}
+		}
+
+		if len(sourceDirs) > 0 {
+			runner = runner.WithSkillInfo(&agent.SkillInfo{
+				MountPath:  agentSpec.Skills.MountPath,
+				SourceDirs: sourceDirs,
+			})
+		}
 	}
 
 	judge, err := llmjudge.NewLLMJudge(r.spec.Config.LLMJudge)
@@ -312,6 +336,16 @@ func (r *evalRunner) buildSummary(agentSpec *agent.AgentSpec, mcpConfig *mcpclie
 				Type:    serverType,
 				URL:     sanitizeURL(server.URL),
 				Command: server.Command,
+			})
+		}
+	}
+
+	// Skills
+	if r.spec.Config.Skills != nil {
+		for _, src := range r.spec.Config.Skills.Sources {
+			summary.Skills = append(summary.Skills, SkillSummary{
+				Type: src.Type,
+				Path: src.Path,
 			})
 		}
 	}
@@ -645,23 +679,26 @@ func (r *evalRunner) executeSingleRun(
 	extResolver resolver.Resolver,
 	tc taskConfig,
 ) *EvalResult {
-	// Create a separate MCP manager for this task
-	taskMcpManager, err := mcpclient.NewManager(ctx, mcpConfig)
-	if err != nil {
-		return &EvalResult{
-			TaskName:   tc.spec.Metadata.Name,
-			TaskPath:   tc.path,
-			Difficulty: tc.spec.Metadata.Difficulty,
-			Parallel:   tc.spec.Metadata.Parallel,
-			TaskPassed: false,
-			TaskError:  fmt.Sprintf("failed to create mcp manager: %v", err),
+	// Create a separate MCP manager for this task (only if MCP is configured)
+	if mcpConfig != nil {
+		taskMcpManager, err := mcpclient.NewManager(ctx, mcpConfig)
+		if err != nil {
+			return &EvalResult{
+				TaskName:   tc.spec.Metadata.Name,
+				TaskPath:   tc.path,
+				Difficulty: tc.spec.Metadata.Difficulty,
+				Parallel:   tc.spec.Metadata.Parallel,
+				TaskPassed: false,
+				TaskError:  fmt.Sprintf("failed to create mcp manager: %v", err),
+			}
 		}
+		defer func() {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_ = taskMcpManager.Close(cleanupCtx)
+		}()
+		ctx = mcpclient.ManagerToContext(ctx, taskMcpManager)
 	}
-	defer func() {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		_ = taskMcpManager.Close(cleanupCtx)
-	}()
 
 	// Create a separate extension manager for this task
 	taskExtManager := client.NewManager(extResolver, client.ExtensionOptions{})
@@ -685,8 +722,7 @@ func (r *evalRunner) executeSingleRun(
 	}
 
 	// Attach task-specific managers to context
-	taskCtx := mcpclient.ManagerToContext(ctx, taskMcpManager)
-	taskCtx = client.ManagerToContext(taskCtx, taskExtManager)
+	taskCtx := client.ManagerToContext(ctx, taskExtManager)
 
 	result, err := r.runTask(taskCtx, agentRunner, tc)
 	if err != nil && result == nil {
@@ -859,23 +895,24 @@ func (r *evalRunner) setupTaskResources(
 	tc taskConfig,
 	result *EvalResult,
 ) (task.TaskRunner, mcpproxy.ServerManager, func(context.Context), error) {
-	mcpManager, ok := mcpclient.ManagerFromContext(ctx)
-	if !ok {
-		return nil, nil, nil, fmt.Errorf("mcp manager not found in context")
-	}
-
 	taskRunner, err := task.NewTaskRunner(ctx, tc.spec)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create task runner for task '%s': %w", tc.spec.Metadata.Name, err)
 	}
 
-	manager, err := mcpproxy.NewServerManager(ctx, mcpManager)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create mcp proxy server manager: %w", err)
-	}
+	var manager mcpproxy.ServerManager
+	mcpManager, ok := mcpclient.ManagerFromContext(ctx)
+	if ok {
+		manager, err = mcpproxy.NewServerManager(ctx, mcpManager)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to create mcp proxy server manager: %w", err)
+		}
 
-	if err := manager.Start(ctx); err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to start mcp proxy servers: %w", err)
+		if err := manager.Start(ctx); err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to start mcp proxy servers: %w", err)
+		}
+	} else {
+		manager = mcpproxy.NewEmptyServerManager()
 	}
 
 	setupOutput, err := taskRunner.Setup(ctx)
@@ -1004,12 +1041,21 @@ func (r *evalRunner) evaluateTaskAssertions(
 	var combinedResults *CompositeAssertionResult
 	allPassed := true
 
+	// Extract agent tool calls for skill assertions
+	var agentToolCalls []agent.ToolCallSummary
+	if result.AgentOutput != nil && result.AgentOutput.AgentDetails != nil {
+		agentToolCalls = result.AgentOutput.AgentDetails.ToolCalls
+	}
+
 	for _, assertions := range tc.assertions {
 		if assertions == nil {
 			continue
 		}
 		evaluator := NewCompositeAssertionEvaluator(assertions)
 		assertionResults := evaluator.Evaluate(callHistory)
+
+		// Evaluate skill assertions against agent tool calls
+		r.evaluateSkillAssertions(assertions, agentToolCalls, assertionResults)
 
 		if combinedResults == nil {
 			combinedResults = assertionResults
@@ -1024,4 +1070,22 @@ func (r *evalRunner) evaluateTaskAssertions(
 
 	result.AssertionResults = combinedResults
 	result.AllAssertionsPassed = allPassed
+}
+
+func (r *evalRunner) evaluateSkillAssertions(
+	assertions *TaskAssertions,
+	toolCalls []agent.ToolCallSummary,
+	results *CompositeAssertionResult,
+) {
+	if r.skillToolName == "" {
+		return
+	}
+
+	if len(assertions.SkillsLoaded) > 0 {
+		results.SkillsLoaded = evaluateSkillsLoaded(assertions.SkillsLoaded, toolCalls, r.skillToolName)
+	}
+
+	if len(assertions.SkillsNotLoaded) > 0 {
+		results.SkillsNotLoaded = evaluateSkillsNotLoaded(assertions.SkillsNotLoaded, toolCalls, r.skillToolName)
+	}
 }

--- a/pkg/eval/runner_test.go
+++ b/pkg/eval/runner_test.go
@@ -306,7 +306,7 @@ func TestLoadMcpConfig(t *testing.T) {
 				assert.Equal(t, "http://localhost:9090/mcp", server.URL)
 			},
 		},
-		"error when neither config file nor env vars available": {
+		"nil config when neither config file nor env vars available": {
 			setupEnv:   clearEnv,
 			cleanupEnv: clearEnv,
 			spec: &EvalSpec{
@@ -314,8 +314,9 @@ func TestLoadMcpConfig(t *testing.T) {
 					McpConfigFile: "",
 				},
 			},
-			expectErr:   true,
-			errContains: "no MCP configuration found",
+			validateFunc: func(t *testing.T, config *mcpclient.MCPConfig) {
+				assert.Nil(t, config)
+			},
 		},
 		"error when config file does not exist": {
 			setupEnv:   clearEnv,
@@ -1023,6 +1024,10 @@ func (f *fakeAgentRunner) RunTask(ctx context.Context, prompt string) (agent.Age
 }
 
 func (f *fakeAgentRunner) WithMcpServerInfo(_ mcpproxy.ServerManager) agent.Runner {
+	return f
+}
+
+func (f *fakeAgentRunner) WithSkillInfo(_ *agent.SkillInfo) agent.Runner {
 	return f
 }
 

--- a/pkg/mcpproxy/server_manager.go
+++ b/pkg/mcpproxy/server_manager.go
@@ -39,6 +39,23 @@ type serverManager struct {
 	eg     *errgroup.Group
 }
 
+// NewEmptyServerManager creates a ServerManager with no servers.
+// Used when MCP is not configured (e.g., skill-only evaluations).
+func NewEmptyServerManager() ServerManager {
+	return &emptyServerManager{}
+}
+
+type emptyServerManager struct{}
+
+func (m *emptyServerManager) GetMcpServerFiles() ([]string, error) { return nil, nil }
+func (m *emptyServerManager) GetMcpServers() []Server              { return nil }
+func (m *emptyServerManager) Start(_ context.Context) error        { return nil }
+func (m *emptyServerManager) Close() error                         { return nil }
+func (m *emptyServerManager) GetAllCallHistory() *CallHistory      { return &CallHistory{} }
+func (m *emptyServerManager) GetCallHistoryForServer(_ string) (CallHistory, bool) {
+	return CallHistory{}, false
+}
+
 func NewServerManager(ctx context.Context, manager mcpclient.Manager) (ServerManager, error) {
 	clients := manager.GetAll()
 	servers := make(map[string]Server, len(clients))

--- a/pkg/task/run.go
+++ b/pkg/task/run.go
@@ -77,9 +77,13 @@ func NewTaskRunner(ctx context.Context, cfg *TaskConfig) (TaskRunner, error) {
 		return nil, fmt.Errorf("failed to get extension manager from context")
 	}
 
-	mcpClientManager, ok := mcpclient.ManagerFromContext(ctx)
-	if !ok {
-		return nil, fmt.Errorf("failed to get mcpclient manager from context")
+	mcpClientManager, hasMcpManager := mcpclient.ManagerFromContext(ctx)
+	if !hasMcpManager {
+		for _, req := range cfg.Spec.Requires {
+			if req.McpServer != nil {
+				return nil, fmt.Errorf("task requires mcpServer %q but no MCP manager is configured", *req.McpServer)
+			}
+		}
 	}
 
 	extensions := make(map[string]string)

--- a/pkg/util/copy.go
+++ b/pkg/util/copy.go
@@ -1,0 +1,92 @@
+package util
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// CopyDir recursively copies the contents of src directory into dst directory.
+// It preserves file permissions. dst is created if it does not exist.
+func CopyDir(src, dst string) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("failed to stat source %q: %w", src, err)
+	}
+	if !srcInfo.IsDir() {
+		return fmt.Errorf("source %q is not a directory", src)
+	}
+
+	if err := os.MkdirAll(dst, srcInfo.Mode()); err != nil {
+		return fmt.Errorf("failed to create destination %q: %w", dst, err)
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return fmt.Errorf("failed to read source directory %q: %w", src, err)
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			if err := CopyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			if err := copyFile(srcPath, dstPath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// MountSkills copies skill source directories into a target directory at the given mount path.
+// It is a no-op if sourceDirs is empty.
+func MountSkills(targetDir, mountPath string, sourceDirs []string) error {
+	if len(sourceDirs) == 0 {
+		return nil
+	}
+
+	mountDir := filepath.Join(targetDir, mountPath)
+	if err := os.MkdirAll(mountDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create skill mount directory %q: %w", mountDir, err)
+	}
+
+	for _, srcDir := range sourceDirs {
+		if err := CopyDir(srcDir, mountDir); err != nil {
+			return fmt.Errorf("failed to copy skills from %q: %w", srcDir, err)
+		}
+	}
+
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open source file %q: %w", src, err)
+	}
+	defer srcFile.Close()
+
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat source file %q: %w", src, err)
+	}
+
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode())
+	if err != nil {
+		return fmt.Errorf("failed to create destination file %q: %w", dst, err)
+	}
+	defer dstFile.Close()
+
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return fmt.Errorf("failed to copy %q to %q: %w", src, dst, err)
+	}
+
+	return nil
+}

--- a/pkg/util/copy.go
+++ b/pkg/util/copy.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // CopyDir recursively copies the contents of src directory into dst directory.
@@ -31,7 +32,14 @@ func CopyDir(src, dst string) error {
 		srcPath := filepath.Join(src, entry.Name())
 		dstPath := filepath.Join(dst, entry.Name())
 
-		if entry.IsDir() {
+		// Resolve symlinks so we copy the target content as regular
+		// files/directories rather than preserving the link itself.
+		info, err := os.Stat(srcPath)
+		if err != nil {
+			return fmt.Errorf("failed to stat %q: %w", srcPath, err)
+		}
+
+		if info.IsDir() {
 			if err := CopyDir(srcPath, dstPath); err != nil {
 				return err
 			}
@@ -52,7 +60,16 @@ func MountSkills(targetDir, mountPath string, sourceDirs []string) error {
 		return nil
 	}
 
-	mountDir := filepath.Join(targetDir, mountPath)
+	if filepath.IsAbs(mountPath) {
+		return fmt.Errorf("skill mount path must be relative, got %q", mountPath)
+	}
+
+	mountDir := filepath.Join(targetDir, filepath.Clean(mountPath))
+	rel, err := filepath.Rel(targetDir, mountDir)
+	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+		return fmt.Errorf("skill mount path %q escapes target directory", mountPath)
+	}
+
 	if err := os.MkdirAll(mountDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create skill mount directory %q: %w", mountDir, err)
 	}
@@ -66,7 +83,7 @@ func MountSkills(targetDir, mountPath string, sourceDirs []string) error {
 	return nil
 }
 
-func copyFile(src, dst string) error {
+func copyFile(src, dst string) (retErr error) {
 	srcFile, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("failed to open source file %q: %w", src, err)
@@ -82,7 +99,11 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create destination file %q: %w", dst, err)
 	}
-	defer dstFile.Close()
+	defer func() {
+		if closeErr := dstFile.Close(); closeErr != nil && retErr == nil {
+			retErr = fmt.Errorf("failed to close destination file %q: %w", dst, closeErr)
+		}
+	}()
 
 	if _, err := io.Copy(dstFile, srcFile); err != nil {
 		return fmt.Errorf("failed to copy %q to %q: %w", src, dst, err)


### PR DESCRIPTION
This PR adds support for evaluating agent skills.

As more people move towards using skills + MCP, this allows us to use our full task/agent harness to see how agents use skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skills system added to mount and use custom skills in agent runs
  * Evaluation now supports skill sources and assertions to validate skill loading
  * Example greeting skill and a sample task that greets "Alice" included

* **Bug Fixes**
  * Safer file-read and session working-directory handling to prevent path-escape issues

* **Documentation**
  * New skill documentation for the greeting skill

* **Tests**
  * Unit tests covering skill-matching logic and related runners
<!-- end of auto-generated comment: release notes by coderabbit.ai -->