### PR TITLE
cleanup(evals): use shared extensions manager

### DIFF
--- a/pkg/eval/runner.go
+++ b/pkg/eval/runner.go
@@ -246,6 +246,21 @@ func (r *evalRunner) RunWithProgress(ctx context.Context, taskPattern string, ca
 		BasePath: r.spec.BasePath(),
 	})
 
+	// Create a shared extension manager for all tasks
+	extManager := client.NewManager(resolver, client.ExtensionOptions{})
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = extManager.ShutdownAll(cleanupCtx)
+	}()
+
+	for alias, ext := range r.spec.Config.Extensions {
+		if err := extManager.Register(alias, ext); err != nil {
+			return nil, fmt.Errorf("failed to register extension %s: %w", alias, err)
+		}
+	}
+
+	ctx = client.ManagerToContext(ctx, extManager)
 	ctx = llmjudge.WithJudge(ctx, judge)
 
 	taskConfigs, err := r.collectTaskConfigs(taskMatcher)
@@ -274,7 +289,7 @@ func (r *evalRunner) RunWithProgress(ctx context.Context, taskPattern string, ca
 			workerLimit = r.parallelWorkers
 		}
 
-		groupResults := r.runTaskGroup(ctx, runner, resolver, group.tasks, workerLimit)
+		groupResults := r.runTaskGroup(ctx, runner, group.tasks, workerLimit)
 		results = append(results, groupResults...)
 	}
 
@@ -549,12 +564,11 @@ func groupTasksByParallelSupport(tasks []taskConfig) []taskGroup {
 }
 
 // runTaskGroup runs a group of tasks with the specified worker limit.
-// Each task gets its own proxy servers and extension managers to ensure isolation,
-// while sharing the underlying MCP client connections from the context.
+// Both MCP client connections and extension manager are shared via context;
+// per-task proxy servers handle call recording and isolation.
 func (r *evalRunner) runTaskGroup(
 	ctx context.Context,
 	agentRunner agent.Runner,
-	extResolver resolver.Resolver,
 	tasks []taskConfig,
 	workerLimit int,
 ) []*EvalResult {
@@ -573,7 +587,7 @@ func (r *evalRunner) runTaskGroup(
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			taskResults := r.executeTask(ctx, agentRunner, extResolver, tc)
+			taskResults := r.executeTask(ctx, agentRunner, tc)
 
 			mu.Lock()
 			allResults = append(allResults, taskResults...)
@@ -692,14 +706,13 @@ func (r *evalRunner) resolveCleanupTimeout(tc taskConfig) (time.Duration, bool, 
 func (r *evalRunner) executeTask(
 	ctx context.Context,
 	agentRunner agent.Runner,
-	extResolver resolver.Resolver,
 	tc taskConfig,
 ) []*EvalResult {
 	runs := r.getRunsForTask(tc)
 	results := make([]*EvalResult, 0, runs)
 
 	for runIdx := 0; runIdx < runs; runIdx++ {
-		result := r.executeSingleRun(ctx, agentRunner, extResolver, tc)
+		result := r.executeSingleRun(ctx, agentRunner, tc)
 		result.RunIndex = runIdx
 		result.TotalRuns = runs
 		results = append(results, result)
@@ -708,41 +721,16 @@ func (r *evalRunner) executeTask(
 	return results
 }
 
-// executeSingleRun runs a single task execution with its own isolated proxy servers
-// and extension managers. The underlying MCP client connections are shared via the
-// context; each task gets its own proxy layer for call recording and isolation.
+// executeSingleRun runs a single task execution.
+// MCP client connections and extension manager are shared via context;
+// per-task proxy servers handle call recording and isolation.
 // Always returns a result, even on error.
 func (r *evalRunner) executeSingleRun(
 	ctx context.Context,
 	agentRunner agent.Runner,
-	extResolver resolver.Resolver,
 	tc taskConfig,
 ) *EvalResult {
-	// Create a separate extension manager for this task
-	taskExtManager := client.NewManager(extResolver, client.ExtensionOptions{})
-	defer func() {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		_ = taskExtManager.ShutdownAll(cleanupCtx)
-	}()
-
-	for alias, ext := range r.spec.Config.Extensions {
-		if err := taskExtManager.Register(alias, ext); err != nil {
-			return &EvalResult{
-				TaskName:   tc.spec.Metadata.Name,
-				TaskPath:   tc.path,
-				Difficulty: tc.spec.Metadata.Difficulty,
-				Parallel:   tc.spec.Metadata.Parallel,
-				TaskPassed: false,
-				TaskError:  fmt.Sprintf("failed to register extension %s: %v", alias, err),
-			}
-		}
-	}
-
-	// Attach task-specific managers to context
-	taskCtx := client.ManagerToContext(ctx, taskExtManager)
-
-	result, err := r.runTask(taskCtx, agentRunner, tc)
+	result, err := r.runTask(ctx, agentRunner, tc)
 	if err != nil && result == nil {
 		return &EvalResult{
 			TaskName:   tc.spec.Metadata.Name,

--- a/pkg/extension/client/manager.go
+++ b/pkg/extension/client/manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mcpchecker/mcpchecker/pkg/extension"
 	"github.com/mcpchecker/mcpchecker/pkg/extension/protocol"
 	"github.com/mcpchecker/mcpchecker/pkg/extension/resolver"
+	"golang.org/x/sync/singleflight"
 )
 
 type ExtensionManager interface {
@@ -30,6 +31,7 @@ type extensionManager struct {
 	specs    map[string]*extension.ExtensionSpec
 	resolver resolver.Resolver
 	opts     ExtensionOptions
+	group    singleflight.Group
 }
 
 type ExtensionOptions struct {
@@ -65,51 +67,65 @@ func (m *extensionManager) Register(alias string, spec *extension.ExtensionSpec)
 }
 
 func (m *extensionManager) Get(ctx context.Context, alias string) (Client, error) {
+	// Fast path: return cached client without blocking other callers
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	if c, ok := m.clients[alias]; ok {
+		m.mu.Unlock()
 		return c, nil
 	}
-
 	spec, ok := m.specs[alias]
+	m.mu.Unlock()
+
 	if !ok {
 		return nil, fmt.Errorf("no extension registered for alias %q", alias)
 	}
 
-	binaryPath, err := m.resolver.Resolve(ctx, spec.Package)
-	if err != nil {
-		return nil, err
-	}
+	// Use singleflight so only one goroutine resolves + starts a given extension,
+	// while concurrent callers for the same alias wait and share the result.
+	// Callers requesting *different* aliases proceed concurrently.
+	v, err, _ := m.group.Do(alias, func() (any, error) {
+		binaryPath, err := m.resolver.Resolve(ctx, spec.Package)
+		if err != nil {
+			return nil, err
+		}
 
-	env, err := expandEnv(spec.Env)
-	if err != nil {
-		return nil, err
-	}
+		env, err := expandEnv(spec.Env)
+		if err != nil {
+			return nil, err
+		}
 
-	c := New(Options{
-		BinaryPath: binaryPath,
-		LogHandler: func(level, message string, data map[string]any) {
-			if m.opts.LogHandler != nil {
-				m.opts.LogHandler(spec.Package, level, message, data)
-			}
-		},
-		Env: env,
+		c := New(Options{
+			BinaryPath: binaryPath,
+			LogHandler: func(level, message string, data map[string]any) {
+				if m.opts.LogHandler != nil {
+					m.opts.LogHandler(spec.Package, level, message, data)
+				}
+			},
+			Env: env,
+		})
+
+		expandedConfig, err := expandConfig(spec.Config)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := c.Start(ctx, &protocol.InitializeParams{
+			Config: expandedConfig,
+		}); err != nil {
+			return nil, err
+		}
+
+		m.mu.Lock()
+		m.clients[alias] = c
+		m.mu.Unlock()
+
+		return c, nil
 	})
-
-	expandedConfig, err := expandConfig(spec.Config)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := c.Start(ctx, &protocol.InitializeParams{
-		Config: expandedConfig,
-	}); err != nil {
-		return nil, err
-	}
-
-	m.clients[alias] = c
-	return c, nil
+	return v.(Client), nil
 }
 
 func (m *extensionManager) Has(alias string) bool {

--- a/pkg/extension/client/manager.go
+++ b/pkg/extension/client/manager.go
@@ -83,8 +83,12 @@ func (m *extensionManager) Get(ctx context.Context, alias string) (Client, error
 	// Use singleflight so only one goroutine resolves + starts a given extension,
 	// while concurrent callers for the same alias wait and share the result.
 	// Callers requesting *different* aliases proceed concurrently.
-	v, err, _ := m.group.Do(alias, func() (any, error) {
-		binaryPath, err := m.resolver.Resolve(ctx, spec.Package)
+	// DoChan + detached context ensures the leader's deadline doesn't cancel
+	// startup for all waiters; each caller can bail on its own ctx independently.
+	ch := m.group.DoChan(alias, func() (any, error) {
+		startupCtx := context.Background()
+
+		binaryPath, err := m.resolver.Resolve(startupCtx, spec.Package)
 		if err != nil {
 			return nil, err
 		}
@@ -109,7 +113,7 @@ func (m *extensionManager) Get(ctx context.Context, alias string) (Client, error
 			return nil, err
 		}
 
-		if err := c.Start(ctx, &protocol.InitializeParams{
+		if err := c.Start(startupCtx, &protocol.InitializeParams{
 			Config: expandedConfig,
 		}); err != nil {
 			return nil, err
@@ -121,11 +125,16 @@ func (m *extensionManager) Get(ctx context.Context, alias string) (Client, error
 
 		return c, nil
 	})
-	if err != nil {
-		return nil, err
-	}
 
-	return v.(Client), nil
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		return res.Val.(Client), nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 func (m *extensionManager) Has(alias string) bool {


### PR DESCRIPTION
While working on #310 I realized that we are currently creating a extension manager per task.

In theory the manager and client it returns is supposed to be thread safe, so this PR moves to the manager being shared across tasks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved extension initialization efficiency by implementing concurrency deduplication, preventing duplicate resolution during parallel task execution.
  * Reorganized extension lifecycle management to centralize initialization at the start of evaluation runs and ensure proper cleanup and state propagation across all tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->